### PR TITLE
Add queue length monitoring functionality and improve context handling

### DIFF
--- a/internal/queue.go
+++ b/internal/queue.go
@@ -44,5 +44,13 @@ func (q *Queue) Dequeue() interface{} {
 }
 
 func (q *Queue) IsEmpty() bool {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
 	return q.items.Len() == 0
+}
+
+func (q *Queue) Length() int {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	return q.items.Len()
 }

--- a/internal/stat.go
+++ b/internal/stat.go
@@ -1,0 +1,20 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func MonitoringStatus(ctx context.Context, queue *Queue) {
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("Monitoring stopped.")
+			return
+		default:
+			fmt.Printf("-----Queue Length: %d-----\n", queue.Length())
+			time.Sleep(5 * time.Second) // Monitor every 5 seconds
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -8,10 +8,9 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
-	"time"
 )
 
-var ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+var ctx, cancel = context.WithCancel(context.Background())
 
 func main() {
 	fmt.Println("Starting message queue...")
@@ -46,6 +45,12 @@ func main() {
 	}()
 
 	fmt.Println("Message queue is running. Press Ctrl+C to stop.")
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		internal.MonitoringStatus(ctx, queue) // Start monitoring the queue status
+	}()
 
 	<-quit
 	fmt.Println("Stopping message queue...")


### PR DESCRIPTION
- 현재 상태 조회를 위해 queue 함수 추가 -> Length
- queue의 length를 주기적으로 출력하는 stat.go 생성해 고루틴에 등록
- main에서 10초후 꺼지게끔 설정된 ctx를 수정