### PR TITLE
Add configuration management with YAML support and persistence options

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,5 @@
+persistence:
+  type: file # memory, file, redis, etc.
+  options:
+    dirs-path: /data/persistence
+  # type : memory # Use in-memory persistence for simplicity

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module go-msg-queue-mini
 
 go 1.24.5
 
-require go.yaml.in/yaml/v3 v3.0.4 // indirect
+require go.yaml.in/yaml/v3 v3.0.4

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module go-msg-queue-mini
 
 go 1.24.5
+
+require go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,0 +1,30 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+
+	"go.yaml.in/yaml/v3"
+)
+
+type Config struct {
+	Persistence struct {
+		Type    string `yaml:"type"`
+		Options struct {
+			DirsPath string `yaml:"dirs-path"`
+		} `yaml:"options"`
+	} `yaml:"persistence"`
+}
+
+func ReadConfig(filePath string) (*Config, error) {
+	yamlFile, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading config file: %w", err)
+	}
+	var config Config
+	err = yaml.Unmarshal(yamlFile, &config)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling config file: %w", err)
+	}
+	return &config, nil
+}

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -1,0 +1,27 @@
+package internal
+
+import (
+	"testing"
+)
+
+func TestReadConfig(t *testing.T) {
+	config, err := ReadConfig("../config.yml")
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	} else {
+		t.Logf("Config read successfully: %+v", config)
+	}
+	config_type := config.Persistence.Type
+	switch config_type {
+	case "memory":
+		t.Logf("Config type is memory: %s", config_type)
+	case "file":
+		t.Logf("Config type is file: %s", config_type)
+		config_options := config.Persistence.Options
+		if config_options.DirsPath == "" {
+			t.Error("DirsPath is empty in file persistence config")
+		} else {
+			t.Logf("DirsPath is set to: %s", config_options.DirsPath)
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces support for reading configuration from a YAML file, enabling the application to be configured for different persistence backends. The main changes include adding a YAML configuration file, implementing a configuration loader, and providing a unit test to verify configuration loading. Additionally, a dependency for YAML parsing is added.

Configuration support:

* Added a new `config.yml` file to specify persistence settings, including type and directory path options.
* Implemented a `Config` struct and a `ReadConfig` function in `internal/config.go` to load and parse the YAML configuration file.
* Added a unit test in `internal/config_test.go` to verify that configuration loading works correctly and validates required fields.

Dependency management:

* Added the `go.yaml.in/yaml/v3` package as a dependency for YAML parsing in `go.mod`.