### PR TITLE
Feat/nack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /data
+AGENTS.md
+GEMINI.md

--- a/config.yml
+++ b/config.yml
@@ -6,3 +6,5 @@ persistence:
   #   max-age: 1 # Maximum age of the file in days
     
   type : memory # Use in-memory persistence for simplicity
+
+max-retry: 3 # Maximum number of retries for message processing

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,13 @@ module go-msg-queue-mini
 
 go 1.24.5
 
-require go.yaml.in/yaml/v3 v3.0.4
+require (
+	github.com/stretchr/testify v1.10.0
+	go.yaml.in/yaml/v3 v3.0.4
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config.go
+++ b/internal/config.go
@@ -16,6 +16,7 @@ type Config struct {
 			MaxAge   int    `yaml:"max-age"`  // Maximum age of the file in days
 		} `yaml:"options"`
 	} `yaml:"persistence"`
+	MaxRetry int `yaml:"max-retry"` // Maximum number of retries for message processing
 }
 
 func ReadConfig(filePath string) (*Config, error) {

--- a/internal/consumer.go
+++ b/internal/consumer.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 func Consume(ctx context.Context, queue Queue, name string) {
@@ -25,6 +26,8 @@ func _consume(queue Queue, name string) {
 			fmt.Printf("Consumed by %s: %s\n", name, msg.Item.(string)) // Log the consumed item
 			if err := queue.Ack(name, msg.Id); err != nil {
 				fmt.Printf("Error acknowledging message %d for %s: %v\n", msg.Id, name, err)
+				queue.Nack(name, msg.Id)           // If Ack fails, Nack the message
+				time.Sleep(100 * time.Millisecond) // Sleep to avoid busy loop
 			}
 		}
 	}

--- a/internal/consumer.go
+++ b/internal/consumer.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"go-msg-queue-mini/util"
 	"time"
 )
 
@@ -23,12 +24,21 @@ func _consume(queue Queue, name string) {
 	messages, err := queue.Dequeue(name, 10) // Dequeue up to 10 messages
 	if err == nil {
 		for _, msg := range messages {
-			fmt.Printf("Consumed by %s: %s\n", name, msg.Item.(string)) // Log the consumed item
-			if err := queue.Ack(name, msg.Id); err != nil {
-				fmt.Printf("Error acknowledging message %d for %s: %v\n", msg.Id, name, err)
-				queue.Nack(name, msg.Id)           // If Ack fails, Nack the message
+			// Simulate message processing failure randomly (1 in 4 chance of failure)
+			if util.GenerateNumber(1, 3) == 1 {
+				fmt.Printf("Consumer %s: NACKing message %d, data: %s\n", name, msg.Id, msg.Item.(string))
+				if err := queue.Nack(name, msg.Id); err != nil {
+					fmt.Printf("Error NACKing message %d for %s: %v\n", msg.Id, name, err)
+				}
 				time.Sleep(100 * time.Millisecond) // Sleep to avoid busy loop
+				break                              // Simulate a processing failure
+			} else {
+				fmt.Printf("Consumer %s: ACKing message %d, data: %s\n", name, msg.Id, msg.Item.(string))
+				if err := queue.Ack(name, msg.Id); err != nil {
+					fmt.Printf("Error ACKing message %d for %s: %v\n", msg.Id, name, err)
+				}
 			}
+			time.Sleep(100 * time.Millisecond) // Sleep to avoid busy loop
 		}
 	}
 }

--- a/internal/queue.go
+++ b/internal/queue.go
@@ -22,6 +22,7 @@ type Queue interface {
 	Enqueue(item interface{}) error
 	Dequeue(consumerID string, maxCount int) ([]Msg, error)
 	Ack(consumerID string, messageID int64) error
+	Nack(consumerID string, messageID int64) error
 	Status() (QueueStatus, error)
 	Shutdown() error
 }

--- a/internal/queueType/file/file_manager.go
+++ b/internal/queueType/file/file_manager.go
@@ -266,22 +266,6 @@ func readMsgFromSegmentFile(filepath string, lastOffset int64, maxCount int) ([]
 	var messages []internal.Msg
 	var msg internal.Msg
 	count := int(0)
-	// for {
-	// 	// _, err := fmt.Fscanf(f, "%v\n", &msg)
-	// 	if err := json.NewDecoder(f).Decode(&msg); err != nil {
-	// 		if err == io.EOF {
-	// 			break // End of file reached
-	// 		}
-	// 		return nil, fmt.Errorf("error reading message from segment file %s: %v", filepath, err)
-	// 	}
-	// 	if msg.Id > lastOffset {
-	// 		messages = append(messages, msg)
-	// 		count++
-	// 		if count >= maxCount {
-	// 			break
-	// 		}
-	// 	}
-	// }
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil {

--- a/internal/queueType/file/file_queue.go
+++ b/internal/queueType/file/file_queue.go
@@ -92,6 +92,22 @@ func (q *fileQueue) Ack(consumerID string, messageID int64) error {
 	return nil
 }
 
+func (q *fileQueue) Nack(consumerID string, messageID int64) error {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
+	if consumerID == "" {
+		return fmt.Errorf("consumer ID is empty")
+	}
+	if messageID == 0 {
+		return fmt.Errorf("message ID is zero")
+	}
+
+	// Handle negative acknowledgment logic here if needed
+	// For now, we just return nil as no specific action is defined
+	return nil
+}
+
 func (q *fileQueue) Shutdown() error {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()

--- a/internal/queueType/file/file_queue_test.go
+++ b/internal/queueType/file/file_queue_test.go
@@ -1,0 +1,115 @@
+package file
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// setupFileQueueTest creates a temporary directory for the test and returns a new fileQueue and the directory path.
+func setupFileQueueTest(t *testing.T) (*fileQueue, string) {
+	tempDir, err := ioutil.TempDir("", "filequeue-test-")
+	assert.NoError(t, err)
+
+	maxRetry := 3
+	q, err := NewFileQueue(tempDir, 1, 1, maxRetry)
+	assert.NoError(t, err)
+
+	return q, tempDir
+}
+
+// teardownFileQueueTest closes the queue and removes the temporary directory.
+func teardownFileQueueTest(t *testing.T, q *fileQueue, tempDir string) {
+	err := q.Shutdown()
+	assert.NoError(t, err)
+	os.RemoveAll(tempDir)
+}
+
+func TestFileQueue_Nack_Retry(t *testing.T) {
+	q, tempDir := setupFileQueueTest(t)
+	defer teardownFileQueueTest(t, q, tempDir)
+
+	consumerID := "test-consumer-retry"
+	msgContent := "test-message"
+
+	// Enqueue and Dequeue
+	assert.NoError(t, q.Enqueue(msgContent))
+	msgs, err := q.Dequeue(consumerID, 1)
+	assert.NoError(t, err)
+	assert.Len(t, msgs, 1)
+	msgID := msgs[0].Id
+
+	// Nack twice
+	assert.NoError(t, q.Nack(consumerID, msgID))
+	assert.NoError(t, q.Nack(consumerID, msgID))
+
+	// Verify retry.state file
+	retryFilePath := filepath.Join(tempDir, "retry.state")
+	data, err := ioutil.ReadFile(retryFilePath)
+	assert.NoError(t, err)
+	expectedRetryState := fmt.Sprintf("%s %d 2\n", consumerID, msgID)
+	assert.Equal(t, expectedRetryState, string(data), "retry.state file content is incorrect")
+}
+
+func TestFileQueue_Nack_MoveToDLQ(t *testing.T) {
+	q, tempDir := setupFileQueueTest(t)
+	defer teardownFileQueueTest(t, q, tempDir)
+
+	t.Logf("Starting TestFileQueue_Nack_MoveToDLQ...")
+
+	consumerID := "test-consumer-dlq"
+	msgContent := "test-message-dlq"
+	q.maxRetry = 2 // Override for this test
+	t.Logf("Queue created with maxRetry=%d", q.maxRetry)
+
+	// Enqueue and Dequeue
+	assert.NoError(t, q.Enqueue(msgContent))
+	t.Logf("Message enqueued: %s", msgContent)
+
+	msgs, err := q.Dequeue(consumerID, 1)
+	assert.NoError(t, err)
+	assert.Len(t, msgs, 1)
+	msg := msgs[0]
+	t.Logf("Message dequeued with ID: %d", msg.Id)
+
+	// Nack until it moves to DLQ
+	for i := 0; i <= q.maxRetry; i++ {
+		t.Logf("Nacking message... Attempt %d", i+1)
+		err := q.Nack(consumerID, msg.Id)
+		assert.NoError(t, err)
+		t.Logf("Nack attempt %d successful", i+1)
+	}
+
+	t.Logf("Finished Nacking. Verifying DLQ status...")
+
+	// Verify DLQ file
+	dlqFilePath := filepath.Join(tempDir, "dead_letter_queue.log")
+	_, err = os.Stat(dlqFilePath)
+	assert.NoError(t, err, "dead_letter_queue.log should exist")
+	t.Logf("DLQ file found.")
+
+	data, err := ioutil.ReadFile(dlqFilePath)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), msgContent, "DLQ file should contain the failed message")
+	t.Logf("DLQ file content verified.")
+
+	// Verify retry.state is empty
+	retryFilePath := filepath.Join(tempDir, "retry.state")
+	data, err = ioutil.ReadFile(retryFilePath)
+	assert.NoError(t, err)
+	assert.Empty(t, string(data), "retry.state should be empty after moving to DLQ")
+	t.Logf("retry.state file verified to be empty.")
+
+	// Verify offset is updated
+	offsetFilePath := filepath.Join(tempDir, "offset.state")
+	data, err = ioutil.ReadFile(offsetFilePath)
+	assert.NoError(t, err)
+	expectedOffsetState := fmt.Sprintf("%s %d\n", consumerID, msg.Id)
+	assert.Equal(t, expectedOffsetState, string(data), "offset.state should be updated to skip the DLQ message")
+	t.Logf("offset.state file verified.")
+	t.Logf("TestFileQueue_Nack_MoveToDLQ finished successfully.")
+}

--- a/internal/queueType/memory/memory_queue_test.go
+++ b/internal/queueType/memory/memory_queue_test.go
@@ -1,0 +1,105 @@
+package memory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemoryQueue_Nack_Retry(t *testing.T) {
+	// Setup
+	maxRetry := 3
+	q := NewMemoryQueue(maxRetry)
+	consumerID := "test-consumer"
+	msgContent := "test-message"
+
+	q.Enqueue(msgContent)
+	msgs, err := q.Dequeue(consumerID, 1)
+	assert.NoError(t, err)
+	assert.Len(t, msgs, 1)
+	msg := msgs[0]
+
+	// Nack 2 times (less than maxRetry)
+	err = q.Nack(consumerID, msg.Id)
+	assert.NoError(t, err)
+	err = q.Nack(consumerID, msg.Id)
+	assert.NoError(t, err)
+
+	// Assertions
+	assert.Equal(t, 2, q.retryMap[consumerID][msg.Id], "Retry count should be 2")
+	assert.Len(t, q.dlq, 0, "DLQ should be empty")
+
+	// Dequeue again, should get the same message
+	// Note: Dequeue updates offset, so we need to reset it for this test
+	delete(q.offsetMap, consumerID)
+	dequeuedMsgs, err := q.Dequeue(consumerID, 1)
+	assert.NoError(t, err)
+	assert.Len(t, dequeuedMsgs, 1)
+	assert.Equal(t, msg.Id, dequeuedMsgs[0].Id, "Should dequeue the same message again")
+}
+
+func TestMemoryQueue_Nack_MoveToDLQ(t *testing.T) {
+	// Setup
+	maxRetry := 2
+	q := NewMemoryQueue(maxRetry)
+	consumerID := "test-consumer-dlq"
+	msgContent := "test-message-dlq"
+
+	q.Enqueue(msgContent)
+	msgs, err := q.Dequeue(consumerID, 1)
+	assert.NoError(t, err)
+	assert.Len(t, msgs, 1)
+	msg := msgs[0]
+
+	// Nack until it moves to DLQ
+	for i := 0; i <= maxRetry; i++ {
+		err = q.Nack(consumerID, msg.Id)
+		assert.NoError(t, err)
+	}
+
+	// Assertions
+	assert.Len(t, q.dlq, 1, "DLQ should contain one message")
+	assert.Equal(t, msg.Id, q.dlq[0].Id, "The correct message should be in the DLQ")
+	_, exists := q.retryMap[consumerID][msg.Id]
+	assert.False(t, exists, "Message should be removed from retry map")
+
+	// The message should be considered "acked" by updating the offset, so it shouldn't be dequeued again
+	dequeuedMsgs, err := q.Dequeue(consumerID, 1)
+	assert.Error(t, err, "Queue should be empty or have no new messages")
+	assert.Len(t, dequeuedMsgs, 0)
+}
+
+func TestMemoryQueue_AckAfterNack(t *testing.T) {
+	// Setup
+	maxRetry := 3
+	q := NewMemoryQueue(maxRetry)
+	consumerID := "test-consumer-ack"
+	msgContent := "test-message-ack"
+
+	q.Enqueue(msgContent)
+	msgs, err := q.Dequeue(consumerID, 1)
+	assert.NoError(t, err)
+	msg := msgs[0]
+
+	// Nack once
+	err = q.Nack(consumerID, msg.Id)
+	assert.NoError(t, err)
+
+	// Assert retry count
+	assert.Equal(t, 1, q.retryMap[consumerID][msg.Id])
+
+	// Dequeue again and Ack
+	// To dequeue the same message, we need to manipulate the offset as Dequeue doesn't guarantee it
+	time.Sleep(1 * time.Millisecond) // Ensure next message has a different ID if we were to enqueue another
+	q.offsetMap[consumerID] = -1
+	dequeuedMsgs, err := q.Dequeue(consumerID, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, msg.Id, dequeuedMsgs[0].Id)
+
+	err = q.Ack(consumerID, msg.Id)
+	assert.NoError(t, err)
+
+	// Assertions
+	assert.Empty(t, q.items, "Queue should be empty after Ack")
+}

--- a/main.go
+++ b/main.go
@@ -25,14 +25,19 @@ func main() {
 		fmt.Printf("Error reading config: %v\n", err)
 		return
 	}
+	maxRetry := config.MaxRetry
+	if maxRetry <= 0 {
+		fmt.Println("Max retry must be greater than 0. Using default value of 3.")
+		maxRetry = 3
+	}
 	// Create a new queue
 	if config.Persistence.Type == "" || config.Persistence.Type == "memory" {
-		queue = memoryqueue.NewMemoryQueue()
+		queue = memoryqueue.NewMemoryQueue(maxRetry)
 	} else if config.Persistence.Type == "file" {
 		logdirs := config.Persistence.Options.DirsPath
 		maxSize := config.Persistence.Options.MaxSize
 		maxAge := config.Persistence.Options.MaxAge
-		queue, err = filequeue.NewFileQueue(logdirs, maxSize, maxAge)
+		queue, err = filequeue.NewFileQueue(logdirs, maxSize, maxAge, maxRetry)
 		if err != nil {
 			fmt.Printf("Error initializing file queue: %v\n", err)
 			return


### PR DESCRIPTION
This pull request introduces a robust retry and dead-letter queue (DLQ) mechanism to the message queue system, enhancing reliability in message processing. It adds configurable retry limits, tracks message failures, and moves messages to a DLQ after exceeding retry attempts. The changes span both in-memory and file-based queue implementations, and include comprehensive tests for the new features.

**Retry and Dead-letter Queue Mechanism**

* Added a configurable `max-retry` option for message processing retries in `config.yml`, and propagated this to both the in-memory and file queue implementations (`Config`, `fileQueue`, `memoryQueue`). [[1]](diffhunk://#diff-5a7db8dbadaef1b1b5a8738ba70b5ffac82b8e243732154165911284e08aad4bR9-R10) [[2]](diffhunk://#diff-0cb36811c5ab07631529c9e82697352bb620d50cf5f88e3e5503bb3e85441caaR19) [[3]](diffhunk://#diff-a616ac95713169adc4a9f82bb7d5b2d0db1bfcc43f82b2d813c951a6b81c3b52R12-R16) [[4]](diffhunk://#diff-41d4a8ffc14728c5b297f8dcd8ac33ea0f65b5bf3189988c57268307e8b42550R11-R26)
* Implemented `Nack` support in the `Queue` interface and both queue types, allowing consumers to signal message processing failures and trigger retries. [[1]](diffhunk://#diff-a4da64775cc564a3505883a36703e06f933dc52ad137cb689289befda3490cf9R25) [[2]](diffhunk://#diff-a616ac95713169adc4a9f82bb7d5b2d0db1bfcc43f82b2d813c951a6b81c3b52R97-R113) [[3]](diffhunk://#diff-41d4a8ffc14728c5b297f8dcd8ac33ea0f65b5bf3189988c57268307e8b42550R77-R155)
* Added persistent tracking of retry counts and DLQ in the file queue, including new state files (`retry.state`, `dead_letter_queue.log`), logic for moving messages to DLQ after exceeding retries, and restoration of retry state on startup. [[1]](diffhunk://#diff-b40adb54a6592e31f9bb60d7b28dc2ef5361bdba855cc160d7b80cacb39f9aafR34-R40) [[2]](diffhunk://#diff-b40adb54a6592e31f9bb60d7b28dc2ef5361bdba855cc160d7b80cacb39f9aafR128-R165) [[3]](diffhunk://#diff-b40adb54a6592e31f9bb60d7b28dc2ef5361bdba855cc160d7b80cacb39f9aafR269-R290) [[4]](diffhunk://#diff-b40adb54a6592e31f9bb60d7b28dc2ef5361bdba855cc160d7b80cacb39f9aafR431-R516)
* Updated the consumer logic to randomly simulate failures and invoke `Nack`, demonstrating and testing the retry/DLQ flow.

**Testing and Validation**

* Added new tests in `file_queue_test.go` to verify retry tracking, DLQ movement, and state file correctness for the file-based queue.

These changes substantially improve the queue's robustness and make message handling more fault-tolerant.