### PR TITLE
Add global ID and partition ID support to fileDB

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/queueType/fileDB/filedb_manager.go
+++ b/internal/queueType/fileDB/filedb_manager.go
@@ -25,6 +25,8 @@ type queueMsg struct {
 	Msg       []byte
 	Insert_ts time.Time
 	Receipt   string
+	GlobalID  string // 복제시 큐메세지 식별용
+	PartitionID int    // 복제시 파티션 식별용
 }
 
 var (
@@ -168,18 +170,44 @@ func (m *fileDBManager) initDB() error {
 
 // create queue table
 func (m *fileDBManager) createQueueTable() error {
+	var res int
+	err := m.db.QueryRow(`select 1 from queue;`).Scan(&res)
+	if err != nil {
+		return err
+	}
+	if res == 1 {
+		return nil
+	}
+
 	createTableSQL :=
 		`CREATE TABLE IF NOT EXISTS queue (
 		id INTEGER PRIMARY KEY,                          -- rowid 기반 고유 PK
     	msg BLOB NOT NULL,                               -- 메시지 본문
+		partition_id INTEGER NOT NULL DEFAULT 0,		 -- 파티션 ID
+		global_id TEXT NOT NULL DEFAULT '',			 -- 글로벌 ID (복제시 사용, UUID 사용)
     	insert_ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 	);`
-	_, err := m.db.Exec(createTableSQL)
-	return err
+	_, err = m.db.Exec(createTableSQL) 
+	if err != nil { return err }
+	createIndex := `CREATE UNIQUE INDEX uq_queue_global ON queue(global_id);`
+	_, err = m.db.Exec(createIndex)
+	if err != nil { return err }
+	createIndex2 := `CREATE INDEX idx_queue_partition ON queue(partition_id, id);`
+	_, err = m.db.Exec(createIndex2)
+	if err != nil { return err }
+	return nil
 }
 
 // create inflight table
 func (m *fileDBManager) createInflightTable() error {
+	var res int
+	err := m.db.QueryRow(`select 1 from inflight;`).Scan(&res)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+	if res == 1 {
+		return nil
+	}
 	createTableSQL :=
 		`CREATE TABLE IF NOT EXISTS inflight (
 		q_id           INTEGER NOT NULL,
@@ -190,13 +218,15 @@ func (m *fileDBManager) createInflightTable() error {
 		receipt        TEXT,
 		last_error     TEXT,
 		claimed_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-		PRIMARY KEY (group_name, q_id)
+		partition_id INTEGER NOT NULL DEFAULT 0,		 -- 파티션 ID
+		global_id TEXT NOT NULL DEFAULT '',			 -- 글로벌 ID (복제시 사용, UUID 사용)
+		PRIMARY KEY (group_name, partition_id, q_id)
 	);`
-	_, err := m.db.Exec(createTableSQL)
+	_, err = m.db.Exec(createTableSQL)
 	if err != nil {
 		return err
 	}
-	createIndex := `CREATE INDEX IF NOT EXISTS idx_inflight_lease ON inflight(group_name, lease_until);`
+	createIndex := `CREATE INDEX IF NOT EXISTS idx_inflight_lease ON inflight(group_name, partition_id, lease_until);`
 	_, err = m.db.Exec(createIndex)
 	if err != nil {
 		return err
@@ -211,49 +241,82 @@ func (m *fileDBManager) createInflightTable() error {
 
 // create acked table
 func (m *fileDBManager) createAckedTable() error {
+	var res int
+	err := m.db.QueryRow(`select 1 from acked;`).Scan(&res)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+	if res == 1 {
+		return nil
+	}
 	createTableSQL :=
 		`CREATE TABLE IF NOT EXISTS acked (
-		q_id        INTEGER NOT NULL,                    -- queue.id
 		group_name  TEXT NOT NULL,                       -- 컨슈머 그룹
+		partition_id INTEGER NOT NULL DEFAULT 0,		 -- 파티션 ID
+		global_id TEXT NOT NULL DEFAULT '',			 -- 글로벌 ID (복제시 사용, UUID 사용)
 		acked_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-		PRIMARY KEY (group_name, q_id)                   -- 그룹별 메시지 1개만 점유 가능
+		PRIMARY KEY (group_name, partition_id, global_id)                   -- 그룹별 메시지 1개만 점유 가능
 	);`
-	_, err := m.db.Exec(createTableSQL)
+	_, err = m.db.Exec(createTableSQL)
 	return err
 }
 
 // create dlq table
 func (m *fileDBManager) createDLQTable() error {
+	var res int
+	err := m.db.QueryRow(`select 1 from dlq;`).Scan(&res)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+	if res == 1 {
+		return nil
+	}
 	createTableSQL :=
 		`CREATE TABLE IF NOT EXISTS dlq (
 		id INTEGER PRIMARY KEY,                          -- rowid 기반 PK
     	q_id INTEGER NOT NULL,                           -- 원본 queue.id
+		partition_id INTEGER NOT NULL DEFAULT 0,		 -- 파티션 ID
+		global_id TEXT NOT NULL DEFAULT '',			 -- 글로벌 ID (복제시 사용, UUID 사용)
     	msg BLOB,                                        -- 메시지 복사본
     	failed_group TEXT,                               -- 실패한 컨슈머 그룹
     	reason TEXT,                                     -- 실패 사유
     	insert_ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP -- 그룹별 메시지 1개만 점유 가능
 	);`
-	_, err := m.db.Exec(createTableSQL)
+	_, err = m.db.Exec(createTableSQL)
 	return err
 }
 
 func (m *fileDBManager) WriteMessage(msg []byte) (err error) {
-	tx, err := m.db.Begin()
-	if err != nil {
+	gid := util.GenerateGlobalID()
+	pid := 0
+	return m.WriteMessageWithMeta(msg, gid, pid)
+}
+
+func (m *fileDBManager) WriteMessageWithMeta(msg []byte, globalID string, partitionID int) (err error) {
+
+	{
+		tx, err := m.db.Begin()
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err != nil {
+				_ = tx.Rollback()
+			} else {
+				err = tx.Commit()
+			}
+		}()
+		_, err = tx.Exec(`INSERT INTO queue (msg, global_id, partition_id) VALUES (?, ?, ?)`, msg, globalID, partitionID)
 		return err
 	}
-	defer func() {
-		if err != nil {
-			_ = tx.Rollback()
-		} else {
-			err = tx.Commit()
-		}
-	}()
-	_, err = tx.Exec(`INSERT INTO queue (msg) VALUES (?)`, msg)
-	return err
 }
 
 func (m *fileDBManager) ReadMessage(group, consumerID string, leaseSec int) (_ queueMsg, err error) {
+	partitionID := 0
+	return m.ReadMessageWithMeta(group, partitionID, consumerID, leaseSec)
+}
+
+func (m *fileDBManager) ReadMessageWithMeta(group string, partitionID int, consumerID string, leaseSec int) (_ queueMsg, err error) {
 	tx, err := m.db.Begin()
 	if err != nil {
 		return queueMsg{}, err
@@ -268,16 +331,18 @@ func (m *fileDBManager) ReadMessage(group, consumerID string, leaseSec int) (_ q
 
 	// 1) 후보 조회
 	var candID int64
+	var globalID string
 	err = tx.QueryRow(`
-        SELECT q.id
-        FROM queue q
-        LEFT JOIN acked a   ON a.q_id = q.id AND a.group_name = ?
-        LEFT JOIN inflight i ON i.q_id = q.id AND i.group_name = ?
-        WHERE a.q_id IS NULL
-          AND (i.q_id IS NULL OR i.lease_until <= CURRENT_TIMESTAMP)
-        ORDER BY q.id ASC
-        LIMIT 1
-    `, group, group).Scan(&candID)
+		SELECT q.id, q.global_id
+		FROM queue q
+		LEFT JOIN acked a   ON a.global_id = q.global_id AND a.group_name = ? AND a.partition_id = ?
+		LEFT JOIN inflight i ON i.q_id = q.id AND i.group_name = ? AND i.partition_id = ?
+		WHERE a.global_id IS NULL
+		  AND (i.q_id IS NULL OR i.lease_until <= CURRENT_TIMESTAMP)
+		  AND q.partition_id = ?
+		ORDER BY q.id ASC
+		LIMIT 1
+	`, group, partitionID, group, partitionID, partitionID).Scan(&candID, &globalID)
 	if err == sql.ErrNoRows {
 		return queueMsg{}, ErrEmpty
 	}
@@ -287,51 +352,59 @@ func (m *fileDBManager) ReadMessage(group, consumerID string, leaseSec int) (_ q
 
 	// 2) 선점 시도 (UPSERT). leaseSec는 정수(초)
 	res, err := tx.Exec(`
-        INSERT INTO inflight(q_id, group_name, consumer_id, lease_until, delivery_count, claimed_at, receipt)
-        SELECT ?, ?, ?, DATETIME('now', ? || ' seconds'),
-               COALESCE((SELECT delivery_count FROM inflight WHERE group_name=? AND q_id=?),0)+1,
-               CURRENT_TIMESTAMP,
-			   lower(hex(randomblob(16))) AS receipt
-        WHERE NOT EXISTS (
-            SELECT 1 FROM inflight
-            WHERE group_name=? AND q_id=? AND lease_until > CURRENT_TIMESTAMP
-        )
-        ON CONFLICT(group_name, q_id) DO UPDATE SET
-          consumer_id    = excluded.consumer_id,
-          lease_until    = excluded.lease_until,
-          delivery_count = inflight.delivery_count + 1,
-          claimed_at     = CURRENT_TIMESTAMP,
-          receipt        = excluded.receipt
+		INSERT INTO inflight(q_id, group_name, consumer_id, lease_until, delivery_count, claimed_at, receipt, partition_id, global_id)
+		SELECT ?, ?, ?, DATETIME('now', ? || ' seconds'),
+			   COALESCE((SELECT delivery_count FROM inflight WHERE group_name=? AND partition_id=? AND q_id=?),0)+1,
+			   CURRENT_TIMESTAMP,
+			   lower(hex(randomblob(16))) AS receipt,
+			   ?, ?
+		WHERE NOT EXISTS (
+			SELECT 1 FROM inflight
+			WHERE group_name=? AND partition_id=? AND q_id=? AND lease_until > CURRENT_TIMESTAMP
+		)
+		ON CONFLICT(group_name, partition_id, q_id) DO UPDATE SET
+		  consumer_id    = excluded.consumer_id,
+		  lease_until    = excluded.lease_until,
+		  delivery_count = inflight.delivery_count + 1,
+		  claimed_at     = CURRENT_TIMESTAMP,
+		  receipt        = excluded.receipt
 		  WHERE inflight.lease_until <= CURRENT_TIMESTAMP
-    `, candID, group, consumerID, leaseSec, group, candID, group, candID)
+	`, candID, group, consumerID, leaseSec, group, partitionID, candID, partitionID, globalID, group, partitionID, candID)
 	if err != nil {
 		return queueMsg{}, err
 	}
-
 	n, _ := res.RowsAffected()
 	if n == 0 {
 		// 경합으로 못 집었음 → 상위 레벨에서 재호출(또는 이 함수 내부에서 짧은 루프)
 		return queueMsg{}, ErrContended
 	}
-
 	// 3) 내가 점유한 메시지 반환 (consumer_id로 한정)
 	var msg queueMsg
 	err = tx.QueryRow(`
-        SELECT q.id, q.msg, q.insert_ts, i.receipt
-        FROM queue q
-        JOIN inflight i ON i.q_id = q.id
-        WHERE i.group_name = ? AND i.consumer_id = ?
-        ORDER BY i.claimed_at DESC
-        LIMIT 1
-    `, group, consumerID).Scan(&msg.Id, &msg.Msg, &msg.Insert_ts, &msg.Receipt)
+		SELECT q.id, q.msg, q.insert_ts, i.receipt, q.global_id, q.partition_id
+		FROM queue q
+		JOIN inflight i ON i.q_id = q.id
+		WHERE i.group_name = ? AND i.consumer_id = ? AND i.partition_id = ?
+		ORDER BY i.claimed_at DESC
+		LIMIT 1
+	`, group, consumerID, partitionID).Scan(&msg.Id, &msg.Msg, &msg.Insert_ts, &msg.Receipt, &msg.GlobalID, &msg.PartitionID)
 	if err != nil {
 		return queueMsg{}, err
 	}
-
 	return msg, nil
 }
 
 func (m *fileDBManager) AckMessage(group string, msgID int64, receipt string) (err error) {
+	var globalID string
+	var partitionID int
+	err = m.db.QueryRow(`SELECT global_id, partition_id FROM queue WHERE id = ?`, msgID).Scan(&globalID, &partitionID)
+	if err != nil {
+		return err
+	}
+	return m.AckMessageWithMeta(group, partitionID, globalID, receipt)
+}
+
+func (m *fileDBManager) AckMessageWithMeta(group string, partitionID int, globalID, receipt string) (err error) {
 	tx, err := m.db.Begin()
 	if err != nil {
 		return err
@@ -343,17 +416,28 @@ func (m *fileDBManager) AckMessage(group string, msgID int64, receipt string) (e
 			err = tx.Commit()
 		}
 	}()
-	if _, err = tx.Exec(`DELETE FROM inflight WHERE q_id = ? AND group_name = ? AND receipt = ?`, msgID, group, receipt); err != nil {
+
+	if _, err = tx.Exec(`DELETE FROM inflight WHERE global_id = ? AND partition_id = ? AND group_name = ? AND receipt = ?`, globalID, partitionID, group, receipt); err != nil {
 		return err
 	}
 
-	if _, err = tx.Exec(`INSERT OR IGNORE INTO acked (q_id, group_name) VALUES (?, ?)`, msgID, group); err != nil {
+	if _, err = tx.Exec(`INSERT OR IGNORE INTO acked (group_name, partition_id, global_id) VALUES (?, ?, ?)`, group, partitionID, globalID); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (m *fileDBManager) NackMessage(group string, msgID int64, receipt string, backoff time.Duration, maxDeliveries int, reason string) (err error) {
+	var globalID string
+	var partitionID int
+	err = m.db.QueryRow(`SELECT global_id, partition_id FROM queue WHERE id = ?`, msgID).Scan(&globalID, &partitionID)
+	if err != nil {
+		return err
+	}
+	return m.NackMessageWithMeta(group, partitionID, globalID, receipt, backoff, maxDeliveries, reason)
+}
+
+func (m *fileDBManager) NackMessageWithMeta(group string, partitionID int, globalID, receipt string, backoff time.Duration, maxDeliveries int, reason string) (err error) {
 	tx, err := m.db.Begin()
 	if err != nil {
 		return err
@@ -368,10 +452,10 @@ func (m *fileDBManager) NackMessage(group string, msgID int64, receipt string, b
 
 	var retryCount int
 	if err = tx.QueryRow(
-		`SELECT delivery_count 
-		FROM inflight 
-		WHERE group_name = ? AND q_id = ?`,
-		group, msgID).Scan(&retryCount); err != nil {
+		`SELECT delivery_count
+		FROM inflight
+		WHERE group_name = ? AND global_id = ? AND partition_id = ? AND receipt = ?`,
+		group, globalID, partitionID, receipt).Scan(&retryCount); err != nil {
 		return err
 	}
 
@@ -391,8 +475,8 @@ func (m *fileDBManager) NackMessage(group string, msgID int64, receipt string, b
         SET lease_until    = DATETIME('now', ? || ' seconds'),
             delivery_count = delivery_count + 1,
             last_error     = ?
-        WHERE group_name = ? AND q_id = ? AND receipt = ?
-    `, backoffSec, reason, group, msgID, receipt)
+        WHERE group_name = ? AND global_id = ? AND partition_id = ? AND receipt = ?
+    `, backoffSec, reason, group, globalID, partitionID, receipt)
 	if err != nil {
 		return err
 	}
@@ -404,26 +488,26 @@ func (m *fileDBManager) NackMessage(group string, msgID int64, receipt string, b
 
 	var dc int
 	if err = tx.QueryRow(`
-        SELECT delivery_count FROM inflight WHERE group_name = ? AND q_id = ? AND receipt = ?
-    `, group, msgID, receipt).Scan(&dc); err != nil {
+        SELECT delivery_count FROM inflight WHERE group_name = ? AND global_id = ? AND partition_id = ? AND receipt = ?
+    `, group, globalID, partitionID, receipt).Scan(&dc); err != nil {
 		return err
 	}
 	if dc > maxDeliveries {
 		if _, err = tx.Exec(`
-		INSERT INTO dlq(q_id, msg, failed_group, reason)
-		SELECT q.id, q.msg, ?, ?
-		FROM queue q WHERE q.id = ?
-        `, group, reason, msgID); err != nil {
+		INSERT INTO dlq(q_id, global_id, partition_id, msg, failed_group, reason)
+		SELECT q.id, q.global_id, q.partition_id, q.msg, ?, ?
+		FROM queue q WHERE q.global_id = ?
+        `, group, reason, globalID); err != nil {
 			return err
 		}
 
-		if _, err = tx.Exec(`DELETE FROM inflight WHERE group_name = ? AND q_id = ? AND receipt = ?`, group, msgID, receipt); err != nil {
+		if _, err = tx.Exec(`DELETE FROM inflight WHERE group_name = ? AND global_id = ? AND partition_id = ? AND receipt = ?`, group, globalID, partitionID, receipt); err != nil {
 			return err
 		}
-		if _, err = tx.Exec(`INSERT OR IGNORE INTO acked (q_id, group_name) VALUES (?, ?)`, msgID, group); err != nil {
+		if _, err = tx.Exec(`INSERT OR IGNORE INTO acked (group_name, partition_id, global_id) VALUES (?, ?, ?)`, group, partitionID, globalID); err != nil {
 			return err
 		}
-		fmt.Printf("Message %d exceeded max deliveries (%d). Moving to DLQ.\n", msgID, maxDeliveries)
+		fmt.Printf("Message %s exceeded max deliveries (%d). Moving to DLQ.\n", globalID, maxDeliveries)
 	}
 	return nil
 }
@@ -460,6 +544,11 @@ func (m *fileDBManager) GetStatus() (internal.QueueStatus, error) {
 }
 
 func (m *fileDBManager) PeekMessage(group string) (_ queueMsg, err error) {
+	partitionID := 0
+	return m.PeekMessageWithMeta(group, partitionID)
+}
+
+func (m *fileDBManager) PeekMessageWithMeta(group string, partitionID int) (_ queueMsg, err error) {
 	tx, err := m.db.Begin()
 	if err != nil {
 		return queueMsg{}, err
@@ -475,15 +564,16 @@ func (m *fileDBManager) PeekMessage(group string) (_ queueMsg, err error) {
 	var msg queueMsg
 	// Implement the logic to peek a message from the queue
 	err = tx.QueryRow(`
-        SELECT q.id, q.msg, q.insert_ts, "" as receipt
-        FROM queue q
-        LEFT JOIN acked a   ON a.q_id = q.id AND a.group_name = ?
-        LEFT JOIN inflight i ON i.q_id = q.id AND i.group_name = ?
-        WHERE a.q_id IS NULL
-          AND (i.q_id IS NULL OR i.lease_until <= CURRENT_TIMESTAMP)
-        ORDER BY q.id ASC
-        LIMIT 1
-    `, group, group).Scan(&msg.Id, &msg.Msg, &msg.Insert_ts, &msg.Receipt)
+		SELECT q.id, q.msg, q.insert_ts, "" as receipt, q.global_id, q.partition_id
+		FROM queue q
+		LEFT JOIN acked a   ON a.global_id = q.global_id AND a.group_name = ? AND a.partition_id = ?
+		LEFT JOIN inflight i ON i.q_id = q.id AND i.group_name = ? AND i.partition_id = ?
+		WHERE a.global_id IS NULL
+		  AND (i.q_id IS NULL OR i.lease_until <= CURRENT_TIMESTAMP)
+		  AND q.partition_id = ?
+		ORDER BY q.id ASC
+		LIMIT 1
+	`, group, partitionID, group, partitionID, partitionID).Scan(&msg.Id, &msg.Msg, &msg.Insert_ts, &msg.Receipt, &msg.GlobalID, &msg.PartitionID)
 	if err == sql.ErrNoRows {
 		return queueMsg{}, ErrEmpty
 	}
@@ -494,15 +584,24 @@ func (m *fileDBManager) PeekMessage(group string) (_ queueMsg, err error) {
 }
 
 func (m *fileDBManager) RenewMessage(group string, msgID int64, receipt string, extendSec int) error {
+	var globalID string
+	err := m.db.QueryRow(`SELECT global_id FROM queue WHERE id = ?`, msgID).Scan(&globalID)
+	if err != nil {
+		return err
+	}
+	return m.RenewMessageWithMeta(group, globalID, receipt, extendSec)
+}
+
+func (m *fileDBManager) RenewMessageWithMeta(group string, globalID, receipt string, extendSec int) error {
 	if extendSec < 1 {
 		extendSec = 1
 	}
 	res, err := m.db.Exec(`
 		UPDATE inflight
 		SET lease_until = DATETIME('now', '+' || ? || ' seconds')
-		WHERE group_name = ? AND q_id = ? AND receipt = ?
+		WHERE group_name = ? AND global_id = ? AND receipt = ?
 		AND lease_until > CURRENT_TIMESTAMP
-	`, extendSec, group, msgID, receipt)
+	`, extendSec, group, globalID, receipt)
 	if err != nil {
 		return err
 	}

--- a/util/uuid.go
+++ b/util/uuid.go
@@ -1,0 +1,11 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+func GenerateGlobalID() string {
+	return fmt.Sprintf("%d", uuid.New().ID())
+}


### PR DESCRIPTION
- 차후 분산 및 복제를 지원하기 위한 partition_id, global_id를 테이블에 추가
- 추가된 칼럼을 기존 함수와 병합