### PR TITLE
Feat/enqueue batch

### DIFF
--- a/internal/api/grpc/queue.pb.go
+++ b/internal/api/grpc/queue.pb.go
@@ -395,6 +395,120 @@ func (x *EnqueueResponse) GetMessage() string {
 	return ""
 }
 
+// EnqueueBatch request
+type EnqueueBatchRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	QueueName     string                 `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
+	Messages      []string               `protobuf:"bytes,2,rep,name=messages,proto3" json:"messages,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnqueueBatchRequest) Reset() {
+	*x = EnqueueBatchRequest{}
+	mi := &file_proto_queue_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnqueueBatchRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnqueueBatchRequest) ProtoMessage() {}
+
+func (x *EnqueueBatchRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_queue_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnqueueBatchRequest.ProtoReflect.Descriptor instead.
+func (*EnqueueBatchRequest) Descriptor() ([]byte, []int) {
+	return file_proto_queue_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *EnqueueBatchRequest) GetQueueName() string {
+	if x != nil {
+		return x.QueueName
+	}
+	return ""
+}
+
+func (x *EnqueueBatchRequest) GetMessages() []string {
+	if x != nil {
+		return x.Messages
+	}
+	return nil
+}
+
+// EnqueueBatch response
+type EnqueueBatchResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Status        string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	QueueName     string                 `protobuf:"bytes,2,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
+	SuccessCount  int64                  `protobuf:"varint,3,opt,name=success_count,json=successCount,proto3" json:"success_count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnqueueBatchResponse) Reset() {
+	*x = EnqueueBatchResponse{}
+	mi := &file_proto_queue_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnqueueBatchResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnqueueBatchResponse) ProtoMessage() {}
+
+func (x *EnqueueBatchResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_queue_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnqueueBatchResponse.ProtoReflect.Descriptor instead.
+func (*EnqueueBatchResponse) Descriptor() ([]byte, []int) {
+	return file_proto_queue_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *EnqueueBatchResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *EnqueueBatchResponse) GetQueueName() string {
+	if x != nil {
+		return x.QueueName
+	}
+	return ""
+}
+
+func (x *EnqueueBatchResponse) GetSuccessCount() int64 {
+	if x != nil {
+		return x.SuccessCount
+	}
+	return 0
+}
+
 // HTTP: DequeueRequest{ group, consumer_id }
 type DequeueRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -407,7 +521,7 @@ type DequeueRequest struct {
 
 func (x *DequeueRequest) Reset() {
 	*x = DequeueRequest{}
-	mi := &file_proto_queue_proto_msgTypes[8]
+	mi := &file_proto_queue_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -419,7 +533,7 @@ func (x *DequeueRequest) String() string {
 func (*DequeueRequest) ProtoMessage() {}
 
 func (x *DequeueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[8]
+	mi := &file_proto_queue_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -432,7 +546,7 @@ func (x *DequeueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DequeueRequest.ProtoReflect.Descriptor instead.
 func (*DequeueRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{8}
+	return file_proto_queue_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *DequeueRequest) GetQueueName() string {
@@ -468,7 +582,7 @@ type DequeueMessage struct {
 
 func (x *DequeueMessage) Reset() {
 	*x = DequeueMessage{}
-	mi := &file_proto_queue_proto_msgTypes[9]
+	mi := &file_proto_queue_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -480,7 +594,7 @@ func (x *DequeueMessage) String() string {
 func (*DequeueMessage) ProtoMessage() {}
 
 func (x *DequeueMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[9]
+	mi := &file_proto_queue_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -493,7 +607,7 @@ func (x *DequeueMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DequeueMessage.ProtoReflect.Descriptor instead.
 func (*DequeueMessage) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{9}
+	return file_proto_queue_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *DequeueMessage) GetPayload() string {
@@ -528,7 +642,7 @@ type DequeueResponse struct {
 
 func (x *DequeueResponse) Reset() {
 	*x = DequeueResponse{}
-	mi := &file_proto_queue_proto_msgTypes[10]
+	mi := &file_proto_queue_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -540,7 +654,7 @@ func (x *DequeueResponse) String() string {
 func (*DequeueResponse) ProtoMessage() {}
 
 func (x *DequeueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[10]
+	mi := &file_proto_queue_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -553,7 +667,7 @@ func (x *DequeueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DequeueResponse.ProtoReflect.Descriptor instead.
 func (*DequeueResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{10}
+	return file_proto_queue_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *DequeueResponse) GetStatus() string {
@@ -583,7 +697,7 @@ type AckRequest struct {
 
 func (x *AckRequest) Reset() {
 	*x = AckRequest{}
-	mi := &file_proto_queue_proto_msgTypes[11]
+	mi := &file_proto_queue_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -595,7 +709,7 @@ func (x *AckRequest) String() string {
 func (*AckRequest) ProtoMessage() {}
 
 func (x *AckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[11]
+	mi := &file_proto_queue_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -608,7 +722,7 @@ func (x *AckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AckRequest.ProtoReflect.Descriptor instead.
 func (*AckRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{11}
+	return file_proto_queue_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *AckRequest) GetQueueName() string {
@@ -648,7 +762,7 @@ type AckResponse struct {
 
 func (x *AckResponse) Reset() {
 	*x = AckResponse{}
-	mi := &file_proto_queue_proto_msgTypes[12]
+	mi := &file_proto_queue_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -660,7 +774,7 @@ func (x *AckResponse) String() string {
 func (*AckResponse) ProtoMessage() {}
 
 func (x *AckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[12]
+	mi := &file_proto_queue_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -673,7 +787,7 @@ func (x *AckResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AckResponse.ProtoReflect.Descriptor instead.
 func (*AckResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{12}
+	return file_proto_queue_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *AckResponse) GetStatus() string {
@@ -696,7 +810,7 @@ type NackRequest struct {
 
 func (x *NackRequest) Reset() {
 	*x = NackRequest{}
-	mi := &file_proto_queue_proto_msgTypes[13]
+	mi := &file_proto_queue_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -708,7 +822,7 @@ func (x *NackRequest) String() string {
 func (*NackRequest) ProtoMessage() {}
 
 func (x *NackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[13]
+	mi := &file_proto_queue_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -721,7 +835,7 @@ func (x *NackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NackRequest.ProtoReflect.Descriptor instead.
 func (*NackRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{13}
+	return file_proto_queue_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *NackRequest) GetQueueName() string {
@@ -761,7 +875,7 @@ type NackResponse struct {
 
 func (x *NackResponse) Reset() {
 	*x = NackResponse{}
-	mi := &file_proto_queue_proto_msgTypes[14]
+	mi := &file_proto_queue_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -773,7 +887,7 @@ func (x *NackResponse) String() string {
 func (*NackResponse) ProtoMessage() {}
 
 func (x *NackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[14]
+	mi := &file_proto_queue_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -786,7 +900,7 @@ func (x *NackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NackResponse.ProtoReflect.Descriptor instead.
 func (*NackResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{14}
+	return file_proto_queue_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *NackResponse) GetStatus() string {
@@ -807,7 +921,7 @@ type PeekRequest struct {
 
 func (x *PeekRequest) Reset() {
 	*x = PeekRequest{}
-	mi := &file_proto_queue_proto_msgTypes[15]
+	mi := &file_proto_queue_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -819,7 +933,7 @@ func (x *PeekRequest) String() string {
 func (*PeekRequest) ProtoMessage() {}
 
 func (x *PeekRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[15]
+	mi := &file_proto_queue_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -832,7 +946,7 @@ func (x *PeekRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PeekRequest.ProtoReflect.Descriptor instead.
 func (*PeekRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{15}
+	return file_proto_queue_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *PeekRequest) GetQueueName() string {
@@ -860,7 +974,7 @@ type PeekResponse struct {
 
 func (x *PeekResponse) Reset() {
 	*x = PeekResponse{}
-	mi := &file_proto_queue_proto_msgTypes[16]
+	mi := &file_proto_queue_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -872,7 +986,7 @@ func (x *PeekResponse) String() string {
 func (*PeekResponse) ProtoMessage() {}
 
 func (x *PeekResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[16]
+	mi := &file_proto_queue_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -885,7 +999,7 @@ func (x *PeekResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PeekResponse.ProtoReflect.Descriptor instead.
 func (*PeekResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{16}
+	return file_proto_queue_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *PeekResponse) GetStatus() string {
@@ -916,7 +1030,7 @@ type RenewRequest struct {
 
 func (x *RenewRequest) Reset() {
 	*x = RenewRequest{}
-	mi := &file_proto_queue_proto_msgTypes[17]
+	mi := &file_proto_queue_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -928,7 +1042,7 @@ func (x *RenewRequest) String() string {
 func (*RenewRequest) ProtoMessage() {}
 
 func (x *RenewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[17]
+	mi := &file_proto_queue_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -941,7 +1055,7 @@ func (x *RenewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewRequest.ProtoReflect.Descriptor instead.
 func (*RenewRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{17}
+	return file_proto_queue_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *RenewRequest) GetQueueName() string {
@@ -988,7 +1102,7 @@ type RenewResponse struct {
 
 func (x *RenewResponse) Reset() {
 	*x = RenewResponse{}
-	mi := &file_proto_queue_proto_msgTypes[18]
+	mi := &file_proto_queue_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1000,7 +1114,7 @@ func (x *RenewResponse) String() string {
 func (*RenewResponse) ProtoMessage() {}
 
 func (x *RenewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[18]
+	mi := &file_proto_queue_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1013,7 +1127,7 @@ func (x *RenewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewResponse.ProtoReflect.Descriptor instead.
 func (*RenewResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{18}
+	return file_proto_queue_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *RenewResponse) GetStatus() string {
@@ -1032,7 +1146,7 @@ type StatusRequest struct {
 
 func (x *StatusRequest) Reset() {
 	*x = StatusRequest{}
-	mi := &file_proto_queue_proto_msgTypes[19]
+	mi := &file_proto_queue_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1044,7 +1158,7 @@ func (x *StatusRequest) String() string {
 func (*StatusRequest) ProtoMessage() {}
 
 func (x *StatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[19]
+	mi := &file_proto_queue_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1057,7 +1171,7 @@ func (x *StatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusRequest.ProtoReflect.Descriptor instead.
 func (*StatusRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{19}
+	return file_proto_queue_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *StatusRequest) GetQueueName() string {
@@ -1078,7 +1192,7 @@ type StatusResponse struct {
 
 func (x *StatusResponse) Reset() {
 	*x = StatusResponse{}
-	mi := &file_proto_queue_proto_msgTypes[20]
+	mi := &file_proto_queue_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1090,7 +1204,7 @@ func (x *StatusResponse) String() string {
 func (*StatusResponse) ProtoMessage() {}
 
 func (x *StatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[20]
+	mi := &file_proto_queue_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1103,7 +1217,7 @@ func (x *StatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusResponse.ProtoReflect.Descriptor instead.
 func (*StatusResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{20}
+	return file_proto_queue_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *StatusResponse) GetStatus() string {
@@ -1134,7 +1248,7 @@ type QueueStatus struct {
 
 func (x *QueueStatus) Reset() {
 	*x = QueueStatus{}
-	mi := &file_proto_queue_proto_msgTypes[21]
+	mi := &file_proto_queue_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1146,7 +1260,7 @@ func (x *QueueStatus) String() string {
 func (*QueueStatus) ProtoMessage() {}
 
 func (x *QueueStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[21]
+	mi := &file_proto_queue_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1159,7 +1273,7 @@ func (x *QueueStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueueStatus.ProtoReflect.Descriptor instead.
 func (*QueueStatus) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{21}
+	return file_proto_queue_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *QueueStatus) GetQueueName() string {
@@ -1223,7 +1337,16 @@ const file_proto_queue_proto_rawDesc = "" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
 	"\n" +
 	"queue_name\x18\x02 \x01(\tR\tqueueName\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage\"f\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\"P\n" +
+	"\x13EnqueueBatchRequest\x12\x1d\n" +
+	"\n" +
+	"queue_name\x18\x01 \x01(\tR\tqueueName\x12\x1a\n" +
+	"\bmessages\x18\x02 \x03(\tR\bmessages\"r\n" +
+	"\x14EnqueueBatchResponse\x12\x16\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
+	"\n" +
+	"queue_name\x18\x02 \x01(\tR\tqueueName\x12#\n" +
+	"\rsuccess_count\x18\x03 \x01(\x03R\fsuccessCount\"f\n" +
 	"\x0eDequeueRequest\x12\x1d\n" +
 	"\n" +
 	"queue_name\x18\x01 \x01(\tR\tqueueName\x12\x14\n" +
@@ -1286,12 +1409,13 @@ const file_proto_queue_proto_rawDesc = "" +
 	"\x0etotal_messages\x18\x02 \x01(\x03R\rtotalMessages\x12%\n" +
 	"\x0eacked_messages\x18\x03 \x01(\x03R\rackedMessages\x12+\n" +
 	"\x11inflight_messages\x18\x04 \x01(\x03R\x10inflightMessages\x12!\n" +
-	"\fdlq_messages\x18\x05 \x01(\x03R\vdlqMessages2\x80\x05\n" +
+	"\fdlq_messages\x18\x05 \x01(\x03R\vdlqMessages2\xcf\x05\n" +
 	"\fQueueService\x12?\n" +
 	"\vHealthCheck\x12\x16.queue.v1.EmptyRequest\x1a\x18.queue.v1.HealthResponse\x12J\n" +
 	"\vCreateQueue\x12\x1c.queue.v1.CreateQueueRequest\x1a\x1d.queue.v1.CreateQueueResponse\x12J\n" +
 	"\vDeleteQueue\x12\x1c.queue.v1.DeleteQueueRequest\x1a\x1d.queue.v1.DeleteQueueResponse\x12>\n" +
-	"\aEnqueue\x12\x18.queue.v1.EnqueueRequest\x1a\x19.queue.v1.EnqueueResponse\x12>\n" +
+	"\aEnqueue\x12\x18.queue.v1.EnqueueRequest\x1a\x19.queue.v1.EnqueueResponse\x12M\n" +
+	"\fEnqueueBatch\x12\x1d.queue.v1.EnqueueBatchRequest\x1a\x1e.queue.v1.EnqueueBatchResponse\x12>\n" +
 	"\aDequeue\x12\x18.queue.v1.DequeueRequest\x1a\x19.queue.v1.DequeueResponse\x122\n" +
 	"\x03Ack\x12\x14.queue.v1.AckRequest\x1a\x15.queue.v1.AckResponse\x125\n" +
 	"\x04Nack\x12\x15.queue.v1.NackRequest\x1a\x16.queue.v1.NackResponse\x125\n" +
@@ -1311,57 +1435,61 @@ func file_proto_queue_proto_rawDescGZIP() []byte {
 	return file_proto_queue_proto_rawDescData
 }
 
-var file_proto_queue_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_proto_queue_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_proto_queue_proto_goTypes = []any{
-	(*EmptyRequest)(nil),        // 0: queue.v1.EmptyRequest
-	(*HealthResponse)(nil),      // 1: queue.v1.HealthResponse
-	(*CreateQueueRequest)(nil),  // 2: queue.v1.CreateQueueRequest
-	(*CreateQueueResponse)(nil), // 3: queue.v1.CreateQueueResponse
-	(*DeleteQueueRequest)(nil),  // 4: queue.v1.DeleteQueueRequest
-	(*DeleteQueueResponse)(nil), // 5: queue.v1.DeleteQueueResponse
-	(*EnqueueRequest)(nil),      // 6: queue.v1.EnqueueRequest
-	(*EnqueueResponse)(nil),     // 7: queue.v1.EnqueueResponse
-	(*DequeueRequest)(nil),      // 8: queue.v1.DequeueRequest
-	(*DequeueMessage)(nil),      // 9: queue.v1.DequeueMessage
-	(*DequeueResponse)(nil),     // 10: queue.v1.DequeueResponse
-	(*AckRequest)(nil),          // 11: queue.v1.AckRequest
-	(*AckResponse)(nil),         // 12: queue.v1.AckResponse
-	(*NackRequest)(nil),         // 13: queue.v1.NackRequest
-	(*NackResponse)(nil),        // 14: queue.v1.NackResponse
-	(*PeekRequest)(nil),         // 15: queue.v1.PeekRequest
-	(*PeekResponse)(nil),        // 16: queue.v1.PeekResponse
-	(*RenewRequest)(nil),        // 17: queue.v1.RenewRequest
-	(*RenewResponse)(nil),       // 18: queue.v1.RenewResponse
-	(*StatusRequest)(nil),       // 19: queue.v1.StatusRequest
-	(*StatusResponse)(nil),      // 20: queue.v1.StatusResponse
-	(*QueueStatus)(nil),         // 21: queue.v1.QueueStatus
+	(*EmptyRequest)(nil),         // 0: queue.v1.EmptyRequest
+	(*HealthResponse)(nil),       // 1: queue.v1.HealthResponse
+	(*CreateQueueRequest)(nil),   // 2: queue.v1.CreateQueueRequest
+	(*CreateQueueResponse)(nil),  // 3: queue.v1.CreateQueueResponse
+	(*DeleteQueueRequest)(nil),   // 4: queue.v1.DeleteQueueRequest
+	(*DeleteQueueResponse)(nil),  // 5: queue.v1.DeleteQueueResponse
+	(*EnqueueRequest)(nil),       // 6: queue.v1.EnqueueRequest
+	(*EnqueueResponse)(nil),      // 7: queue.v1.EnqueueResponse
+	(*EnqueueBatchRequest)(nil),  // 8: queue.v1.EnqueueBatchRequest
+	(*EnqueueBatchResponse)(nil), // 9: queue.v1.EnqueueBatchResponse
+	(*DequeueRequest)(nil),       // 10: queue.v1.DequeueRequest
+	(*DequeueMessage)(nil),       // 11: queue.v1.DequeueMessage
+	(*DequeueResponse)(nil),      // 12: queue.v1.DequeueResponse
+	(*AckRequest)(nil),           // 13: queue.v1.AckRequest
+	(*AckResponse)(nil),          // 14: queue.v1.AckResponse
+	(*NackRequest)(nil),          // 15: queue.v1.NackRequest
+	(*NackResponse)(nil),         // 16: queue.v1.NackResponse
+	(*PeekRequest)(nil),          // 17: queue.v1.PeekRequest
+	(*PeekResponse)(nil),         // 18: queue.v1.PeekResponse
+	(*RenewRequest)(nil),         // 19: queue.v1.RenewRequest
+	(*RenewResponse)(nil),        // 20: queue.v1.RenewResponse
+	(*StatusRequest)(nil),        // 21: queue.v1.StatusRequest
+	(*StatusResponse)(nil),       // 22: queue.v1.StatusResponse
+	(*QueueStatus)(nil),          // 23: queue.v1.QueueStatus
 }
 var file_proto_queue_proto_depIdxs = []int32{
-	9,  // 0: queue.v1.DequeueResponse.message:type_name -> queue.v1.DequeueMessage
-	9,  // 1: queue.v1.PeekResponse.message:type_name -> queue.v1.DequeueMessage
-	21, // 2: queue.v1.StatusResponse.queue_status:type_name -> queue.v1.QueueStatus
+	11, // 0: queue.v1.DequeueResponse.message:type_name -> queue.v1.DequeueMessage
+	11, // 1: queue.v1.PeekResponse.message:type_name -> queue.v1.DequeueMessage
+	23, // 2: queue.v1.StatusResponse.queue_status:type_name -> queue.v1.QueueStatus
 	0,  // 3: queue.v1.QueueService.HealthCheck:input_type -> queue.v1.EmptyRequest
 	2,  // 4: queue.v1.QueueService.CreateQueue:input_type -> queue.v1.CreateQueueRequest
 	4,  // 5: queue.v1.QueueService.DeleteQueue:input_type -> queue.v1.DeleteQueueRequest
 	6,  // 6: queue.v1.QueueService.Enqueue:input_type -> queue.v1.EnqueueRequest
-	8,  // 7: queue.v1.QueueService.Dequeue:input_type -> queue.v1.DequeueRequest
-	11, // 8: queue.v1.QueueService.Ack:input_type -> queue.v1.AckRequest
-	13, // 9: queue.v1.QueueService.Nack:input_type -> queue.v1.NackRequest
-	15, // 10: queue.v1.QueueService.Peek:input_type -> queue.v1.PeekRequest
-	17, // 11: queue.v1.QueueService.Renew:input_type -> queue.v1.RenewRequest
-	19, // 12: queue.v1.QueueService.Status:input_type -> queue.v1.StatusRequest
-	1,  // 13: queue.v1.QueueService.HealthCheck:output_type -> queue.v1.HealthResponse
-	3,  // 14: queue.v1.QueueService.CreateQueue:output_type -> queue.v1.CreateQueueResponse
-	5,  // 15: queue.v1.QueueService.DeleteQueue:output_type -> queue.v1.DeleteQueueResponse
-	7,  // 16: queue.v1.QueueService.Enqueue:output_type -> queue.v1.EnqueueResponse
-	10, // 17: queue.v1.QueueService.Dequeue:output_type -> queue.v1.DequeueResponse
-	12, // 18: queue.v1.QueueService.Ack:output_type -> queue.v1.AckResponse
-	14, // 19: queue.v1.QueueService.Nack:output_type -> queue.v1.NackResponse
-	16, // 20: queue.v1.QueueService.Peek:output_type -> queue.v1.PeekResponse
-	18, // 21: queue.v1.QueueService.Renew:output_type -> queue.v1.RenewResponse
-	20, // 22: queue.v1.QueueService.Status:output_type -> queue.v1.StatusResponse
-	13, // [13:23] is the sub-list for method output_type
-	3,  // [3:13] is the sub-list for method input_type
+	8,  // 7: queue.v1.QueueService.EnqueueBatch:input_type -> queue.v1.EnqueueBatchRequest
+	10, // 8: queue.v1.QueueService.Dequeue:input_type -> queue.v1.DequeueRequest
+	13, // 9: queue.v1.QueueService.Ack:input_type -> queue.v1.AckRequest
+	15, // 10: queue.v1.QueueService.Nack:input_type -> queue.v1.NackRequest
+	17, // 11: queue.v1.QueueService.Peek:input_type -> queue.v1.PeekRequest
+	19, // 12: queue.v1.QueueService.Renew:input_type -> queue.v1.RenewRequest
+	21, // 13: queue.v1.QueueService.Status:input_type -> queue.v1.StatusRequest
+	1,  // 14: queue.v1.QueueService.HealthCheck:output_type -> queue.v1.HealthResponse
+	3,  // 15: queue.v1.QueueService.CreateQueue:output_type -> queue.v1.CreateQueueResponse
+	5,  // 16: queue.v1.QueueService.DeleteQueue:output_type -> queue.v1.DeleteQueueResponse
+	7,  // 17: queue.v1.QueueService.Enqueue:output_type -> queue.v1.EnqueueResponse
+	9,  // 18: queue.v1.QueueService.EnqueueBatch:output_type -> queue.v1.EnqueueBatchResponse
+	12, // 19: queue.v1.QueueService.Dequeue:output_type -> queue.v1.DequeueResponse
+	14, // 20: queue.v1.QueueService.Ack:output_type -> queue.v1.AckResponse
+	16, // 21: queue.v1.QueueService.Nack:output_type -> queue.v1.NackResponse
+	18, // 22: queue.v1.QueueService.Peek:output_type -> queue.v1.PeekResponse
+	20, // 23: queue.v1.QueueService.Renew:output_type -> queue.v1.RenewResponse
+	22, // 24: queue.v1.QueueService.Status:output_type -> queue.v1.StatusResponse
+	14, // [14:25] is the sub-list for method output_type
+	3,  // [3:14] is the sub-list for method input_type
 	3,  // [3:3] is the sub-list for extension type_name
 	3,  // [3:3] is the sub-list for extension extendee
 	0,  // [0:3] is the sub-list for field type_name
@@ -1378,7 +1506,7 @@ func file_proto_queue_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_queue_proto_rawDesc), len(file_proto_queue_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   22,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/api/grpc/server.go
+++ b/internal/api/grpc/server.go
@@ -115,7 +115,7 @@ func (qs *queueServiceServer) EnqueueBatch(ctx context.Context, req *EnqueueBatc
 	if err != nil {
 		return nil, err
 	}
-	return &EnqueueBatchResponse{Status: "ok", SuccessCount: int64(successCount)}, nil
+	return &EnqueueBatchResponse{Status: "ok", QueueName: queue_name, SuccessCount: int64(successCount)}, nil
 }
 
 func (qs *queueServiceServer) Dequeue(ctx context.Context, req *DequeueRequest) (res *DequeueResponse, err error) {

--- a/internal/api/grpc/server.go
+++ b/internal/api/grpc/server.go
@@ -21,16 +21,17 @@ func StartServer(ctx context.Context, config *internal.Config, queue internal.Qu
 		return err
 	}
 	protectedMethods := map[string]bool{
-		"/queue.v1.QueueService/CreateQueue": true,
-		"/queue.v1.QueueService/DeleteQueue": true,
-		"/queue.v1.QueueService/Enqueue":     true,
-		"/queue.v1.QueueService/Dequeue":     true,
-		"/queue.v1.QueueService/Ack":         true,
-		"/queue.v1.QueueService/Nack":        true,
-		"/queue.v1.QueueService/Renew":       true,
-		"/queue.v1.QueueService/Peek":        false,
-		"/queue.v1.QueueService/Status":      false,
-		"/queue.v1.QueueService/HealthCheck": false,
+		"/queue.v1.QueueService/CreateQueue":  true,
+		"/queue.v1.QueueService/DeleteQueue":  true,
+		"/queue.v1.QueueService/Enqueue":      true,
+		"/queue.v1.QueueService/EnqueueBatch": true,
+		"/queue.v1.QueueService/Dequeue":      true,
+		"/queue.v1.QueueService/Ack":          true,
+		"/queue.v1.QueueService/Nack":         true,
+		"/queue.v1.QueueService/Renew":        true,
+		"/queue.v1.QueueService/Peek":         false,
+		"/queue.v1.QueueService/Status":       false,
+		"/queue.v1.QueueService/HealthCheck":  false,
 	}
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
@@ -95,6 +96,26 @@ func (qs *queueServiceServer) Enqueue(ctx context.Context, req *EnqueueRequest) 
 		return nil, err
 	}
 	return &EnqueueResponse{Status: "ok", Message: message}, nil
+}
+
+func (qs *queueServiceServer) EnqueueBatch(ctx context.Context, req *EnqueueBatchRequest) (res *EnqueueBatchResponse, err error) {
+	queue_name := req.GetQueueName()
+	if queue_name == "" {
+		return nil, fmt.Errorf("queue name is required")
+	}
+	messages := req.GetMessages()
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("messages are required")
+	}
+	msgs := make([]interface{}, len(messages))
+	for i, msg := range messages {
+		msgs[i] = msg
+	}
+	successCount, err := qs.Queue.EnqueueBatch(queue_name, msgs)
+	if err != nil {
+		return nil, err
+	}
+	return &EnqueueBatchResponse{Status: "ok", SuccessCount: int64(successCount)}, nil
 }
 
 func (qs *queueServiceServer) Dequeue(ctx context.Context, req *DequeueRequest) (res *DequeueResponse, err error) {

--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -68,6 +68,11 @@ func TestQueueServiceEnqueueBatchSuccess(t *testing.T) {
 	if resp.GetStatus() != "ok" {
 		t.Fatalf("response status = %s, want ok", resp.GetStatus())
 	}
+
+	if resp.GetQueueName() != "test-queue" {
+		t.Fatalf("queue name = %s, want test-queue", resp.GetQueueName())
+	}
+
 	if resp.GetSuccessCount() != int64(mq.enqueueBatchResult) {
 		t.Fatalf("success count = %d, want %d", resp.GetSuccessCount(), mq.enqueueBatchResult)
 	}
@@ -141,4 +146,3 @@ func TestQueueServiceEnqueueBatchQueueError(t *testing.T) {
 		t.Fatalf("enqueue batch call count = %d, want 1", len(mq.enqueueBatchCalls))
 	}
 }
-

--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -1,0 +1,144 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"go-msg-queue-mini/internal"
+	"go-msg-queue-mini/internal/queue_error"
+)
+
+type enqueueBatchCall struct {
+	queueName string
+	items     []interface{}
+}
+
+type mockQueue struct {
+	enqueueBatchResult int
+	enqueueBatchError  error
+	enqueueBatchCalls  []enqueueBatchCall
+}
+
+func (m *mockQueue) CreateQueue(string) error { return nil }
+
+func (m *mockQueue) DeleteQueue(string) error { return nil }
+
+func (m *mockQueue) Enqueue(string, interface{}) error { return nil }
+
+func (m *mockQueue) EnqueueBatch(queueName string, items []interface{}) (int, error) {
+	m.enqueueBatchCalls = append(m.enqueueBatchCalls, enqueueBatchCall{queueName: queueName, items: items})
+	return m.enqueueBatchResult, m.enqueueBatchError
+}
+
+func (m *mockQueue) Dequeue(string, string, string) (internal.QueueMessage, error) {
+	return internal.QueueMessage{}, queue_error.ErrEmpty
+}
+
+func (m *mockQueue) Ack(string, string, int64, string) error { return nil }
+
+func (m *mockQueue) Nack(string, string, int64, string) error { return nil }
+
+func (m *mockQueue) Status(string) (internal.QueueStatus, error) {
+	return internal.QueueStatus{}, nil
+}
+
+func (m *mockQueue) Shutdown() error { return nil }
+
+func (m *mockQueue) Peek(string, string) (internal.QueueMessage, error) {
+	return internal.QueueMessage{}, queue_error.ErrEmpty
+}
+
+func (m *mockQueue) Renew(string, string, int64, string, int) error { return nil }
+
+func TestQueueServiceEnqueueBatchSuccess(t *testing.T) {
+	mq := &mockQueue{enqueueBatchResult: 2}
+	server := NewQueueServiceServer(mq)
+
+	req := &EnqueueBatchRequest{
+		QueueName: "test-queue",
+		Messages:  []string{"first", "second"},
+	}
+
+	resp, err := server.EnqueueBatch(context.Background(), req)
+	if err != nil {
+		t.Fatalf("enqueue batch returned error: %v", err)
+	}
+	if resp.GetStatus() != "ok" {
+		t.Fatalf("response status = %s, want ok", resp.GetStatus())
+	}
+	if resp.GetSuccessCount() != int64(mq.enqueueBatchResult) {
+		t.Fatalf("success count = %d, want %d", resp.GetSuccessCount(), mq.enqueueBatchResult)
+	}
+
+	if len(mq.enqueueBatchCalls) != 1 {
+		t.Fatalf("enqueue batch call count = %d, want 1", len(mq.enqueueBatchCalls))
+	}
+	call := mq.enqueueBatchCalls[0]
+	if call.queueName != "test-queue" {
+		t.Fatalf("queue name = %s, want test-queue", call.queueName)
+	}
+	expectedItems := []interface{}{"first", "second"}
+	if !reflect.DeepEqual(call.items, expectedItems) {
+		t.Fatalf("enqueue items = %#v, want %#v", call.items, expectedItems)
+	}
+}
+
+func TestQueueServiceEnqueueBatchMissingQueueName(t *testing.T) {
+	mq := &mockQueue{}
+	server := NewQueueServiceServer(mq)
+
+	req := &EnqueueBatchRequest{QueueName: "", Messages: []string{"msg"}}
+
+	resp, err := server.EnqueueBatch(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error when queue name missing")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response on error")
+	}
+	if len(mq.enqueueBatchCalls) != 0 {
+		t.Fatalf("enqueue batch should not be called when queue name missing")
+	}
+}
+
+func TestQueueServiceEnqueueBatchEmptyMessages(t *testing.T) {
+	mq := &mockQueue{}
+	server := NewQueueServiceServer(mq)
+
+	req := &EnqueueBatchRequest{QueueName: "test-queue", Messages: []string{}}
+
+	resp, err := server.EnqueueBatch(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error when messages are empty")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response on empty messages")
+	}
+	if len(mq.enqueueBatchCalls) != 0 {
+		t.Fatalf("enqueue batch should not be called when messages empty")
+	}
+}
+
+func TestQueueServiceEnqueueBatchQueueError(t *testing.T) {
+	mq := &mockQueue{enqueueBatchError: errors.New("boom")}
+	server := NewQueueServiceServer(mq)
+
+	req := &EnqueueBatchRequest{QueueName: "test-queue", Messages: []string{"msg"}}
+
+	resp, err := server.EnqueueBatch(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error from queue")
+	}
+	if !errors.Is(err, mq.enqueueBatchError) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response on queue error")
+	}
+	if len(mq.enqueueBatchCalls) != 1 {
+		t.Fatalf("enqueue batch call count = %d, want 1", len(mq.enqueueBatchCalls))
+	}
+}
+

--- a/internal/api/http/dto.go
+++ b/internal/api/http/dto.go
@@ -11,6 +11,15 @@ type EnqueueResponse struct {
 	Message json.RawMessage `json:"message"`
 }
 
+type EnqueueBatchRequest struct {
+	Messages []json.RawMessage `json:"messages" binding:"required"`
+}
+
+type EnqueueBatchResponse struct {
+	Status       string `json:"status"`
+	SuccessCount int    `json:"success_count"`
+}
+
 type DequeueRequest struct {
 	Group      string `json:"group" binding:"required"`
 	ConsumerID string `json:"consumer_id" binding:"required"`

--- a/internal/api/http/handler_test.go
+++ b/internal/api/http/handler_test.go
@@ -1,0 +1,175 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"go-msg-queue-mini/internal"
+	"go-msg-queue-mini/internal/queue_error"
+)
+
+type enqueueBatchCall struct {
+	queueName string
+	items     []interface{}
+}
+
+type mockQueue struct {
+	enqueueBatchResult int
+	enqueueBatchError  error
+	enqueueBatchCalls  []enqueueBatchCall
+}
+
+func (m *mockQueue) CreateQueue(string) error { return nil }
+
+func (m *mockQueue) DeleteQueue(string) error { return nil }
+
+func (m *mockQueue) Enqueue(string, interface{}) error { return nil }
+
+func (m *mockQueue) EnqueueBatch(queueName string, items []interface{}) (int, error) {
+	m.enqueueBatchCalls = append(m.enqueueBatchCalls, enqueueBatchCall{queueName: queueName, items: items})
+	return m.enqueueBatchResult, m.enqueueBatchError
+}
+
+func (m *mockQueue) Dequeue(string, string, string) (internal.QueueMessage, error) {
+	return internal.QueueMessage{}, queue_error.ErrEmpty
+}
+
+func (m *mockQueue) Ack(string, string, int64, string) error { return nil }
+
+func (m *mockQueue) Nack(string, string, int64, string) error { return nil }
+
+func (m *mockQueue) Status(string) (internal.QueueStatus, error) { return internal.QueueStatus{}, nil }
+
+func (m *mockQueue) Shutdown() error { return nil }
+
+func (m *mockQueue) Peek(string, string) (internal.QueueMessage, error) {
+	return internal.QueueMessage{}, queue_error.ErrEmpty
+}
+
+func (m *mockQueue) Renew(string, string, int64, string, int) error { return nil }
+
+func TestEnqueueBatchHandlerSuccess(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mq := &mockQueue{enqueueBatchResult: 2}
+	server := &httpServerInstance{Queue: mq}
+
+	body := EnqueueBatchRequest{
+		Messages: []json.RawMessage{
+			json.RawMessage(`{"foo":"bar"}`),
+			json.RawMessage(`42`),
+		},
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("queue_name", "test-queue")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/test-queue/enqueue/batch", bytes.NewReader(encoded))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	server.enqueueBatchHandler(c)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusAccepted)
+	}
+
+	if len(mq.enqueueBatchCalls) != 1 {
+		t.Fatalf("enqueue batch call count = %d, want 1", len(mq.enqueueBatchCalls))
+	}
+	call := mq.enqueueBatchCalls[0]
+	if call.queueName != "test-queue" {
+		t.Fatalf("queue name = %s, want test-queue", call.queueName)
+	}
+	expectedItems := []interface{}{
+		json.RawMessage(`{"foo":"bar"}`),
+		json.RawMessage(`42`),
+	}
+	if len(call.items) != len(expectedItems) {
+		t.Fatalf("items length = %d, want %d", len(call.items), len(expectedItems))
+	}
+	for i, item := range call.items {
+		exp := expectedItems[i]
+		rawItem, ok := item.(json.RawMessage)
+		if !ok {
+			t.Fatalf("item %d type = %T, want json.RawMessage", i, item)
+		}
+		rawExp, ok := exp.(json.RawMessage)
+		if !ok {
+			t.Fatalf("expected item %d type = %T, want json.RawMessage", i, exp)
+		}
+		if !bytes.Equal([]byte(rawItem), []byte(rawExp)) {
+			t.Fatalf("item %d = %s, want %s", i, rawItem, rawExp)
+		}
+	}
+
+	var resp EnqueueBatchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.Status != "enqueued" {
+		t.Fatalf("response status = %s, want enqueued", resp.Status)
+	}
+	if resp.SuccessCount != mq.enqueueBatchResult {
+		t.Fatalf("success count = %d, want %d", resp.SuccessCount, mq.enqueueBatchResult)
+	}
+}
+
+func TestEnqueueBatchHandlerBindError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mq := &mockQueue{}
+	server := &httpServerInstance{Queue: mq}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("queue_name", "oops-queue")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/oops-queue/enqueue/batch", bytes.NewBufferString(`{"invalid":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	server.enqueueBatchHandler(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if len(mq.enqueueBatchCalls) != 0 {
+		t.Fatalf("enqueue batch should not be called on bind error")
+	}
+}
+
+func TestEnqueueBatchHandlerQueueError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mq := &mockQueue{enqueueBatchError: errors.New("boom")}
+	server := &httpServerInstance{Queue: mq}
+
+	body := EnqueueBatchRequest{Messages: []json.RawMessage{json.RawMessage(`"msg"`)}}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("queue_name", "err-queue")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/err-queue/enqueue/batch", bytes.NewReader(encoded))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	server.enqueueBatchHandler(c)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+	if len(mq.enqueueBatchCalls) != 1 {
+		t.Fatalf("enqueue batch call count = %d, want 1", len(mq.enqueueBatchCalls))
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -101,6 +101,7 @@ func router(httpServerInstance *httpServerInstance) *gin.Engine {
 		writer.POST("/:queue_name/create", httpServerInstance.createQueueHandler)
 		writer.DELETE("/:queue_name/delete", httpServerInstance.deleteQueueHandler)
 		writer.POST("/:queue_name/enqueue", httpServerInstance.enqueueHandler)
+		writer.POST("/:queue_name/enqueue/batch", httpServerInstance.enqueueBatchHandler)
 		writer.POST("/:queue_name/dequeue", httpServerInstance.dequeueHandler)
 		writer.POST("/:queue_name/ack", httpServerInstance.ackHandler)
 		writer.POST("/:queue_name/nack", httpServerInstance.nackHandler)

--- a/internal/core/filedb_manager.go
+++ b/internal/core/filedb_manager.go
@@ -421,12 +421,11 @@ func (m *FileDBManager) WriteMessageWithMeta(queue_name string, msg []byte, glob
 }
 
 func (m *FileDBManager) WriteMessagesBatch(queue_name string, msgs [][]byte) (int, error) {
-	gid := util.GenerateGlobalID()
 	pid := 0
-	return m.WriteMessagesBatchWithMeta(queue_name, msgs, gid, pid)
+	return m.WriteMessagesBatchWithMeta(queue_name, msgs, pid)
 }
 
-func (m *FileDBManager) WriteMessagesBatchWithMeta(queue_name string, msgs [][]byte, globalID string, partitionID int) (int, error) {
+func (m *FileDBManager) WriteMessagesBatchWithMeta(queue_name string, msgs [][]byte, partitionID int) (int, error) {
 	queueInfoID, err := m.getQueueInfoID(queue_name)
 	if err != nil {
 		return 0, err
@@ -434,6 +433,7 @@ func (m *FileDBManager) WriteMessagesBatchWithMeta(queue_name string, msgs [][]b
 	successCount := 0
 	err = m.inTx(func(tx *sql.Tx) error {
 		for _, msg := range msgs {
+			globalID := util.GenerateGlobalID()
 			_, insertErr := tx.Exec(`
 				INSERT INTO queue 
 				(queue_info_id, msg, global_id, partition_id) 

--- a/internal/core/filedb_queue_test.go
+++ b/internal/core/filedb_queue_test.go
@@ -1,0 +1,89 @@
+package core
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"go-msg-queue-mini/internal"
+	"go-msg-queue-mini/internal/queue_error"
+)
+
+func newTestConfig() *internal.Config {
+	cfg := &internal.Config{
+		MaxRetry:      3,
+		RetryInterval: "1s",
+		LeaseDuration: "30s",
+	}
+	cfg.Persistence.Type = "memory"
+	return cfg
+}
+
+func TestFileDBQueueEnqueueBatchSuccess(t *testing.T) {
+	queue, err := NewFileDBQueue(newTestConfig())
+	if err != nil {
+		t.Fatalf("failed to create filedb queue: %v", err)
+	}
+	defer func() {
+		if shutdownErr := queue.Shutdown(); shutdownErr != nil {
+			t.Fatalf("failed to shutdown queue: %v", shutdownErr)
+		}
+	}()
+
+	queueName := "enqueue-batch-success"
+	if err := queue.CreateQueue(queueName); err != nil {
+		t.Fatalf("failed to create queue: %v", err)
+	}
+
+	batch := []interface{}{"first", map[string]interface{}{"foo": "bar"}}
+	successCount, err := queue.EnqueueBatch(queueName, batch)
+	if err != nil {
+		t.Fatalf("enqueue batch returned error: %v", err)
+	}
+	if successCount != len(batch) {
+		t.Fatalf("enqueue batch success count = %d, want %d", successCount, len(batch))
+	}
+
+	expected := []interface{}{"first", map[string]interface{}{"foo": "bar"}}
+	for idx, want := range expected {
+		msg, err := queue.Dequeue(queueName, "group-A", "consumer-1")
+		if err != nil {
+			t.Fatalf("dequeue failed at index %d: %v", idx, err)
+		}
+		if !reflect.DeepEqual(msg.Payload, want) {
+			t.Fatalf("dequeued payload = %#v, want %#v", msg.Payload, want)
+		}
+		if ackErr := queue.Ack(queueName, "group-A", msg.ID, msg.Receipt); ackErr != nil {
+			t.Fatalf("ack failed for message %d: %v", idx, ackErr)
+		}
+	}
+
+	if _, err := queue.Dequeue(queueName, "group-A", "consumer-1"); !errors.Is(err, queue_error.ErrEmpty) {
+		t.Fatalf("expected empty queue after acking, got error: %v", err)
+	}
+}
+
+func TestFileDBQueueEnqueueBatchQueueNotFound(t *testing.T) {
+	queue, err := NewFileDBQueue(newTestConfig())
+	if err != nil {
+		t.Fatalf("failed to create filedb queue: %v", err)
+	}
+	defer func() {
+		if shutdownErr := queue.Shutdown(); shutdownErr != nil {
+			t.Fatalf("failed to shutdown queue: %v", shutdownErr)
+		}
+	}()
+
+	batch := []interface{}{"no-queue"}
+	successCount, err := queue.EnqueueBatch("missing-queue", batch)
+	if err == nil {
+		t.Fatal("expected error when enqueueing to missing queue, got nil")
+	}
+	if successCount != 0 {
+		t.Fatalf("success count = %d, want 0", successCount)
+	}
+	if !strings.Contains(err.Error(), "queue not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/queue.go
+++ b/internal/queue.go
@@ -20,6 +20,7 @@ type Queue interface {
 	CreateQueue(queue_name string) error
 	DeleteQueue(queue_name string) error
 	Enqueue(queue_name string, item interface{}) error
+	EnqueueBatch(queue_name string, items []interface{}) (int, error)
 	Dequeue(queue_name string, group_name string, consumer_id string) (QueueMessage, error)
 	Ack(queue_name string, group_name string, messageID int64, receipt string) error
 	Nack(queue_name string, group_name string, messageID int64, receipt string) error

--- a/proto/queue.proto
+++ b/proto/queue.proto
@@ -25,6 +25,9 @@ service QueueService {
   // Enqueue: 메시지를 큐에 적재
   rpc Enqueue(EnqueueRequest) returns (EnqueueResponse);
 
+  // EnqueueBatch : 메세지 n개를 큐에 한번에 적재
+  rpc EnqueueBatch(EnqueueBatchRequest) returns (EnqueueBatchResponse);
+
   // Dequeue: 그룹/컨슈머 기준으로 메시지 하나를 임대(lease)하여 가져옴
   // - 큐가 비었으면 NOT_FOUND로 반환 권장
   // - 경합이면 ABORTED/FAILED_PRECONDITION 권장
@@ -88,6 +91,19 @@ message EnqueueResponse {
   string status = 1;           // e.g., "enqueued"
   string queue_name = 2;
   string  message = 3;          // 원본 페이로드 에코백
+}
+
+// EnqueueBatch request
+message EnqueueBatchRequest {
+  string queue_name = 1;
+  repeated string messages = 2;
+}
+
+// EnqueueBatch response
+message EnqueueBatchResponse {
+  string status = 1;
+  string queue_name = 2;
+  int64 success_count = 3;
 }
 
 // HTTP: DequeueRequest{ group, consumer_id }


### PR DESCRIPTION
- queue.proto에 EnqueueBatch RPC 메서드를 도입하여 여러 메시지를 동시에 큐에 넣을 수 있도록 했습니다.
- QueueServiceServer 및 QueueServiceClient에 EnqueueBatch를 구현했습니다.
- 일괄 큐에 넣기 위한 해당 HTTP 핸들러와 경로를 추가했습니다.
- 메시지 일괄 쓰기를 지원하도록 FileDBManager를 업데이트했습니다.
- 일괄 큐에 넣기 로직을 ​​처리하도록 filedb_queue를 개선했습니다.
- EnqueueBatch 메서드를 포함하도록 Queue 인터페이스를 수정했습니다.
- EnqueueBatchRequest 및 EnqueueBatchResponse에 대한 DTO를 생성했습니다.
- 테스트 코드를 생성했습니다.

