### PR TITLE
Refact/improve enqueue batch

### DIFF
--- a/internal/api/grpc/queue.pb.go
+++ b/internal/api/grpc/queue.pb.go
@@ -399,7 +399,8 @@ func (x *EnqueueResponse) GetMessage() string {
 type EnqueueBatchRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	QueueName     string                 `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
-	Messages      []string               `protobuf:"bytes,2,rep,name=messages,proto3" json:"messages,omitempty"`
+	Mode          string                 `protobuf:"bytes,2,opt,name=mode,proto3" json:"mode,omitempty"`
+	Messages      []string               `protobuf:"bytes,3,rep,name=messages,proto3" json:"messages,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -441,6 +442,13 @@ func (x *EnqueueBatchRequest) GetQueueName() string {
 	return ""
 }
 
+func (x *EnqueueBatchRequest) GetMode() string {
+	if x != nil {
+		return x.Mode
+	}
+	return ""
+}
+
 func (x *EnqueueBatchRequest) GetMessages() []string {
 	if x != nil {
 		return x.Messages
@@ -450,12 +458,14 @@ func (x *EnqueueBatchRequest) GetMessages() []string {
 
 // EnqueueBatch response
 type EnqueueBatchResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Status        string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
-	QueueName     string                 `protobuf:"bytes,2,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
-	SuccessCount  int64                  `protobuf:"varint,3,opt,name=success_count,json=successCount,proto3" json:"success_count,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Status         string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	QueueName      string                 `protobuf:"bytes,2,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
+	SuccessCount   int64                  `protobuf:"varint,3,opt,name=success_count,json=successCount,proto3" json:"success_count,omitempty"`
+	FailureCount   int64                  `protobuf:"varint,4,opt,name=failure_count,json=failureCount,proto3" json:"failure_count,omitempty"`
+	FailedMessages []*FailedMessage       `protobuf:"bytes,5,rep,name=failed_messages,json=failedMessages,proto3" json:"failed_messages,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *EnqueueBatchResponse) Reset() {
@@ -509,6 +519,81 @@ func (x *EnqueueBatchResponse) GetSuccessCount() int64 {
 	return 0
 }
 
+func (x *EnqueueBatchResponse) GetFailureCount() int64 {
+	if x != nil {
+		return x.FailureCount
+	}
+	return 0
+}
+
+func (x *EnqueueBatchResponse) GetFailedMessages() []*FailedMessage {
+	if x != nil {
+		return x.FailedMessages
+	}
+	return nil
+}
+
+// FailedMessage
+type FailedMessage struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Index         int64                  `protobuf:"varint,1,opt,name=index,proto3" json:"index,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	Error         string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *FailedMessage) Reset() {
+	*x = FailedMessage{}
+	mi := &file_proto_queue_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *FailedMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*FailedMessage) ProtoMessage() {}
+
+func (x *FailedMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_queue_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use FailedMessage.ProtoReflect.Descriptor instead.
+func (*FailedMessage) Descriptor() ([]byte, []int) {
+	return file_proto_queue_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *FailedMessage) GetIndex() int64 {
+	if x != nil {
+		return x.Index
+	}
+	return 0
+}
+
+func (x *FailedMessage) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *FailedMessage) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
 // HTTP: DequeueRequest{ group, consumer_id }
 type DequeueRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -521,7 +606,7 @@ type DequeueRequest struct {
 
 func (x *DequeueRequest) Reset() {
 	*x = DequeueRequest{}
-	mi := &file_proto_queue_proto_msgTypes[10]
+	mi := &file_proto_queue_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -533,7 +618,7 @@ func (x *DequeueRequest) String() string {
 func (*DequeueRequest) ProtoMessage() {}
 
 func (x *DequeueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[10]
+	mi := &file_proto_queue_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -546,7 +631,7 @@ func (x *DequeueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DequeueRequest.ProtoReflect.Descriptor instead.
 func (*DequeueRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{10}
+	return file_proto_queue_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *DequeueRequest) GetQueueName() string {
@@ -582,7 +667,7 @@ type DequeueMessage struct {
 
 func (x *DequeueMessage) Reset() {
 	*x = DequeueMessage{}
-	mi := &file_proto_queue_proto_msgTypes[11]
+	mi := &file_proto_queue_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -594,7 +679,7 @@ func (x *DequeueMessage) String() string {
 func (*DequeueMessage) ProtoMessage() {}
 
 func (x *DequeueMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[11]
+	mi := &file_proto_queue_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -607,7 +692,7 @@ func (x *DequeueMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DequeueMessage.ProtoReflect.Descriptor instead.
 func (*DequeueMessage) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{11}
+	return file_proto_queue_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *DequeueMessage) GetPayload() string {
@@ -642,7 +727,7 @@ type DequeueResponse struct {
 
 func (x *DequeueResponse) Reset() {
 	*x = DequeueResponse{}
-	mi := &file_proto_queue_proto_msgTypes[12]
+	mi := &file_proto_queue_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -654,7 +739,7 @@ func (x *DequeueResponse) String() string {
 func (*DequeueResponse) ProtoMessage() {}
 
 func (x *DequeueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[12]
+	mi := &file_proto_queue_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -667,7 +752,7 @@ func (x *DequeueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DequeueResponse.ProtoReflect.Descriptor instead.
 func (*DequeueResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{12}
+	return file_proto_queue_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DequeueResponse) GetStatus() string {
@@ -697,7 +782,7 @@ type AckRequest struct {
 
 func (x *AckRequest) Reset() {
 	*x = AckRequest{}
-	mi := &file_proto_queue_proto_msgTypes[13]
+	mi := &file_proto_queue_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -709,7 +794,7 @@ func (x *AckRequest) String() string {
 func (*AckRequest) ProtoMessage() {}
 
 func (x *AckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[13]
+	mi := &file_proto_queue_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -722,7 +807,7 @@ func (x *AckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AckRequest.ProtoReflect.Descriptor instead.
 func (*AckRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{13}
+	return file_proto_queue_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *AckRequest) GetQueueName() string {
@@ -762,7 +847,7 @@ type AckResponse struct {
 
 func (x *AckResponse) Reset() {
 	*x = AckResponse{}
-	mi := &file_proto_queue_proto_msgTypes[14]
+	mi := &file_proto_queue_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -774,7 +859,7 @@ func (x *AckResponse) String() string {
 func (*AckResponse) ProtoMessage() {}
 
 func (x *AckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[14]
+	mi := &file_proto_queue_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -787,7 +872,7 @@ func (x *AckResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AckResponse.ProtoReflect.Descriptor instead.
 func (*AckResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{14}
+	return file_proto_queue_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *AckResponse) GetStatus() string {
@@ -810,7 +895,7 @@ type NackRequest struct {
 
 func (x *NackRequest) Reset() {
 	*x = NackRequest{}
-	mi := &file_proto_queue_proto_msgTypes[15]
+	mi := &file_proto_queue_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -822,7 +907,7 @@ func (x *NackRequest) String() string {
 func (*NackRequest) ProtoMessage() {}
 
 func (x *NackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[15]
+	mi := &file_proto_queue_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -835,7 +920,7 @@ func (x *NackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NackRequest.ProtoReflect.Descriptor instead.
 func (*NackRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{15}
+	return file_proto_queue_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *NackRequest) GetQueueName() string {
@@ -875,7 +960,7 @@ type NackResponse struct {
 
 func (x *NackResponse) Reset() {
 	*x = NackResponse{}
-	mi := &file_proto_queue_proto_msgTypes[16]
+	mi := &file_proto_queue_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -887,7 +972,7 @@ func (x *NackResponse) String() string {
 func (*NackResponse) ProtoMessage() {}
 
 func (x *NackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[16]
+	mi := &file_proto_queue_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -900,7 +985,7 @@ func (x *NackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NackResponse.ProtoReflect.Descriptor instead.
 func (*NackResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{16}
+	return file_proto_queue_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *NackResponse) GetStatus() string {
@@ -921,7 +1006,7 @@ type PeekRequest struct {
 
 func (x *PeekRequest) Reset() {
 	*x = PeekRequest{}
-	mi := &file_proto_queue_proto_msgTypes[17]
+	mi := &file_proto_queue_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -933,7 +1018,7 @@ func (x *PeekRequest) String() string {
 func (*PeekRequest) ProtoMessage() {}
 
 func (x *PeekRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[17]
+	mi := &file_proto_queue_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -946,7 +1031,7 @@ func (x *PeekRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PeekRequest.ProtoReflect.Descriptor instead.
 func (*PeekRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{17}
+	return file_proto_queue_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *PeekRequest) GetQueueName() string {
@@ -974,7 +1059,7 @@ type PeekResponse struct {
 
 func (x *PeekResponse) Reset() {
 	*x = PeekResponse{}
-	mi := &file_proto_queue_proto_msgTypes[18]
+	mi := &file_proto_queue_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -986,7 +1071,7 @@ func (x *PeekResponse) String() string {
 func (*PeekResponse) ProtoMessage() {}
 
 func (x *PeekResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[18]
+	mi := &file_proto_queue_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -999,7 +1084,7 @@ func (x *PeekResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PeekResponse.ProtoReflect.Descriptor instead.
 func (*PeekResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{18}
+	return file_proto_queue_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *PeekResponse) GetStatus() string {
@@ -1030,7 +1115,7 @@ type RenewRequest struct {
 
 func (x *RenewRequest) Reset() {
 	*x = RenewRequest{}
-	mi := &file_proto_queue_proto_msgTypes[19]
+	mi := &file_proto_queue_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1042,7 +1127,7 @@ func (x *RenewRequest) String() string {
 func (*RenewRequest) ProtoMessage() {}
 
 func (x *RenewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[19]
+	mi := &file_proto_queue_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1055,7 +1140,7 @@ func (x *RenewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewRequest.ProtoReflect.Descriptor instead.
 func (*RenewRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{19}
+	return file_proto_queue_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *RenewRequest) GetQueueName() string {
@@ -1102,7 +1187,7 @@ type RenewResponse struct {
 
 func (x *RenewResponse) Reset() {
 	*x = RenewResponse{}
-	mi := &file_proto_queue_proto_msgTypes[20]
+	mi := &file_proto_queue_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1114,7 +1199,7 @@ func (x *RenewResponse) String() string {
 func (*RenewResponse) ProtoMessage() {}
 
 func (x *RenewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[20]
+	mi := &file_proto_queue_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1127,7 +1212,7 @@ func (x *RenewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewResponse.ProtoReflect.Descriptor instead.
 func (*RenewResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{20}
+	return file_proto_queue_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *RenewResponse) GetStatus() string {
@@ -1146,7 +1231,7 @@ type StatusRequest struct {
 
 func (x *StatusRequest) Reset() {
 	*x = StatusRequest{}
-	mi := &file_proto_queue_proto_msgTypes[21]
+	mi := &file_proto_queue_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1158,7 +1243,7 @@ func (x *StatusRequest) String() string {
 func (*StatusRequest) ProtoMessage() {}
 
 func (x *StatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[21]
+	mi := &file_proto_queue_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1171,7 +1256,7 @@ func (x *StatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusRequest.ProtoReflect.Descriptor instead.
 func (*StatusRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{21}
+	return file_proto_queue_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *StatusRequest) GetQueueName() string {
@@ -1192,7 +1277,7 @@ type StatusResponse struct {
 
 func (x *StatusResponse) Reset() {
 	*x = StatusResponse{}
-	mi := &file_proto_queue_proto_msgTypes[22]
+	mi := &file_proto_queue_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1204,7 +1289,7 @@ func (x *StatusResponse) String() string {
 func (*StatusResponse) ProtoMessage() {}
 
 func (x *StatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[22]
+	mi := &file_proto_queue_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1217,7 +1302,7 @@ func (x *StatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusResponse.ProtoReflect.Descriptor instead.
 func (*StatusResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{22}
+	return file_proto_queue_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *StatusResponse) GetStatus() string {
@@ -1248,7 +1333,7 @@ type QueueStatus struct {
 
 func (x *QueueStatus) Reset() {
 	*x = QueueStatus{}
-	mi := &file_proto_queue_proto_msgTypes[23]
+	mi := &file_proto_queue_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1260,7 +1345,7 @@ func (x *QueueStatus) String() string {
 func (*QueueStatus) ProtoMessage() {}
 
 func (x *QueueStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[23]
+	mi := &file_proto_queue_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1273,7 +1358,7 @@ func (x *QueueStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueueStatus.ProtoReflect.Descriptor instead.
 func (*QueueStatus) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{23}
+	return file_proto_queue_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *QueueStatus) GetQueueName() string {
@@ -1337,16 +1422,23 @@ const file_proto_queue_proto_rawDesc = "" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
 	"\n" +
 	"queue_name\x18\x02 \x01(\tR\tqueueName\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage\"P\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\"d\n" +
 	"\x13EnqueueBatchRequest\x12\x1d\n" +
 	"\n" +
-	"queue_name\x18\x01 \x01(\tR\tqueueName\x12\x1a\n" +
-	"\bmessages\x18\x02 \x03(\tR\bmessages\"r\n" +
+	"queue_name\x18\x01 \x01(\tR\tqueueName\x12\x12\n" +
+	"\x04mode\x18\x02 \x01(\tR\x04mode\x12\x1a\n" +
+	"\bmessages\x18\x03 \x03(\tR\bmessages\"\xd9\x01\n" +
 	"\x14EnqueueBatchResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
 	"\n" +
 	"queue_name\x18\x02 \x01(\tR\tqueueName\x12#\n" +
-	"\rsuccess_count\x18\x03 \x01(\x03R\fsuccessCount\"f\n" +
+	"\rsuccess_count\x18\x03 \x01(\x03R\fsuccessCount\x12#\n" +
+	"\rfailure_count\x18\x04 \x01(\x03R\ffailureCount\x12@\n" +
+	"\x0ffailed_messages\x18\x05 \x03(\v2\x17.queue.v1.FailedMessageR\x0efailedMessages\"U\n" +
+	"\rFailedMessage\x12\x14\n" +
+	"\x05index\x18\x01 \x01(\x03R\x05index\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"f\n" +
 	"\x0eDequeueRequest\x12\x1d\n" +
 	"\n" +
 	"queue_name\x18\x01 \x01(\tR\tqueueName\x12\x14\n" +
@@ -1435,7 +1527,7 @@ func file_proto_queue_proto_rawDescGZIP() []byte {
 	return file_proto_queue_proto_rawDescData
 }
 
-var file_proto_queue_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_proto_queue_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_proto_queue_proto_goTypes = []any{
 	(*EmptyRequest)(nil),         // 0: queue.v1.EmptyRequest
 	(*HealthResponse)(nil),       // 1: queue.v1.HealthResponse
@@ -1447,52 +1539,54 @@ var file_proto_queue_proto_goTypes = []any{
 	(*EnqueueResponse)(nil),      // 7: queue.v1.EnqueueResponse
 	(*EnqueueBatchRequest)(nil),  // 8: queue.v1.EnqueueBatchRequest
 	(*EnqueueBatchResponse)(nil), // 9: queue.v1.EnqueueBatchResponse
-	(*DequeueRequest)(nil),       // 10: queue.v1.DequeueRequest
-	(*DequeueMessage)(nil),       // 11: queue.v1.DequeueMessage
-	(*DequeueResponse)(nil),      // 12: queue.v1.DequeueResponse
-	(*AckRequest)(nil),           // 13: queue.v1.AckRequest
-	(*AckResponse)(nil),          // 14: queue.v1.AckResponse
-	(*NackRequest)(nil),          // 15: queue.v1.NackRequest
-	(*NackResponse)(nil),         // 16: queue.v1.NackResponse
-	(*PeekRequest)(nil),          // 17: queue.v1.PeekRequest
-	(*PeekResponse)(nil),         // 18: queue.v1.PeekResponse
-	(*RenewRequest)(nil),         // 19: queue.v1.RenewRequest
-	(*RenewResponse)(nil),        // 20: queue.v1.RenewResponse
-	(*StatusRequest)(nil),        // 21: queue.v1.StatusRequest
-	(*StatusResponse)(nil),       // 22: queue.v1.StatusResponse
-	(*QueueStatus)(nil),          // 23: queue.v1.QueueStatus
+	(*FailedMessage)(nil),        // 10: queue.v1.FailedMessage
+	(*DequeueRequest)(nil),       // 11: queue.v1.DequeueRequest
+	(*DequeueMessage)(nil),       // 12: queue.v1.DequeueMessage
+	(*DequeueResponse)(nil),      // 13: queue.v1.DequeueResponse
+	(*AckRequest)(nil),           // 14: queue.v1.AckRequest
+	(*AckResponse)(nil),          // 15: queue.v1.AckResponse
+	(*NackRequest)(nil),          // 16: queue.v1.NackRequest
+	(*NackResponse)(nil),         // 17: queue.v1.NackResponse
+	(*PeekRequest)(nil),          // 18: queue.v1.PeekRequest
+	(*PeekResponse)(nil),         // 19: queue.v1.PeekResponse
+	(*RenewRequest)(nil),         // 20: queue.v1.RenewRequest
+	(*RenewResponse)(nil),        // 21: queue.v1.RenewResponse
+	(*StatusRequest)(nil),        // 22: queue.v1.StatusRequest
+	(*StatusResponse)(nil),       // 23: queue.v1.StatusResponse
+	(*QueueStatus)(nil),          // 24: queue.v1.QueueStatus
 }
 var file_proto_queue_proto_depIdxs = []int32{
-	11, // 0: queue.v1.DequeueResponse.message:type_name -> queue.v1.DequeueMessage
-	11, // 1: queue.v1.PeekResponse.message:type_name -> queue.v1.DequeueMessage
-	23, // 2: queue.v1.StatusResponse.queue_status:type_name -> queue.v1.QueueStatus
-	0,  // 3: queue.v1.QueueService.HealthCheck:input_type -> queue.v1.EmptyRequest
-	2,  // 4: queue.v1.QueueService.CreateQueue:input_type -> queue.v1.CreateQueueRequest
-	4,  // 5: queue.v1.QueueService.DeleteQueue:input_type -> queue.v1.DeleteQueueRequest
-	6,  // 6: queue.v1.QueueService.Enqueue:input_type -> queue.v1.EnqueueRequest
-	8,  // 7: queue.v1.QueueService.EnqueueBatch:input_type -> queue.v1.EnqueueBatchRequest
-	10, // 8: queue.v1.QueueService.Dequeue:input_type -> queue.v1.DequeueRequest
-	13, // 9: queue.v1.QueueService.Ack:input_type -> queue.v1.AckRequest
-	15, // 10: queue.v1.QueueService.Nack:input_type -> queue.v1.NackRequest
-	17, // 11: queue.v1.QueueService.Peek:input_type -> queue.v1.PeekRequest
-	19, // 12: queue.v1.QueueService.Renew:input_type -> queue.v1.RenewRequest
-	21, // 13: queue.v1.QueueService.Status:input_type -> queue.v1.StatusRequest
-	1,  // 14: queue.v1.QueueService.HealthCheck:output_type -> queue.v1.HealthResponse
-	3,  // 15: queue.v1.QueueService.CreateQueue:output_type -> queue.v1.CreateQueueResponse
-	5,  // 16: queue.v1.QueueService.DeleteQueue:output_type -> queue.v1.DeleteQueueResponse
-	7,  // 17: queue.v1.QueueService.Enqueue:output_type -> queue.v1.EnqueueResponse
-	9,  // 18: queue.v1.QueueService.EnqueueBatch:output_type -> queue.v1.EnqueueBatchResponse
-	12, // 19: queue.v1.QueueService.Dequeue:output_type -> queue.v1.DequeueResponse
-	14, // 20: queue.v1.QueueService.Ack:output_type -> queue.v1.AckResponse
-	16, // 21: queue.v1.QueueService.Nack:output_type -> queue.v1.NackResponse
-	18, // 22: queue.v1.QueueService.Peek:output_type -> queue.v1.PeekResponse
-	20, // 23: queue.v1.QueueService.Renew:output_type -> queue.v1.RenewResponse
-	22, // 24: queue.v1.QueueService.Status:output_type -> queue.v1.StatusResponse
-	14, // [14:25] is the sub-list for method output_type
-	3,  // [3:14] is the sub-list for method input_type
-	3,  // [3:3] is the sub-list for extension type_name
-	3,  // [3:3] is the sub-list for extension extendee
-	0,  // [0:3] is the sub-list for field type_name
+	10, // 0: queue.v1.EnqueueBatchResponse.failed_messages:type_name -> queue.v1.FailedMessage
+	12, // 1: queue.v1.DequeueResponse.message:type_name -> queue.v1.DequeueMessage
+	12, // 2: queue.v1.PeekResponse.message:type_name -> queue.v1.DequeueMessage
+	24, // 3: queue.v1.StatusResponse.queue_status:type_name -> queue.v1.QueueStatus
+	0,  // 4: queue.v1.QueueService.HealthCheck:input_type -> queue.v1.EmptyRequest
+	2,  // 5: queue.v1.QueueService.CreateQueue:input_type -> queue.v1.CreateQueueRequest
+	4,  // 6: queue.v1.QueueService.DeleteQueue:input_type -> queue.v1.DeleteQueueRequest
+	6,  // 7: queue.v1.QueueService.Enqueue:input_type -> queue.v1.EnqueueRequest
+	8,  // 8: queue.v1.QueueService.EnqueueBatch:input_type -> queue.v1.EnqueueBatchRequest
+	11, // 9: queue.v1.QueueService.Dequeue:input_type -> queue.v1.DequeueRequest
+	14, // 10: queue.v1.QueueService.Ack:input_type -> queue.v1.AckRequest
+	16, // 11: queue.v1.QueueService.Nack:input_type -> queue.v1.NackRequest
+	18, // 12: queue.v1.QueueService.Peek:input_type -> queue.v1.PeekRequest
+	20, // 13: queue.v1.QueueService.Renew:input_type -> queue.v1.RenewRequest
+	22, // 14: queue.v1.QueueService.Status:input_type -> queue.v1.StatusRequest
+	1,  // 15: queue.v1.QueueService.HealthCheck:output_type -> queue.v1.HealthResponse
+	3,  // 16: queue.v1.QueueService.CreateQueue:output_type -> queue.v1.CreateQueueResponse
+	5,  // 17: queue.v1.QueueService.DeleteQueue:output_type -> queue.v1.DeleteQueueResponse
+	7,  // 18: queue.v1.QueueService.Enqueue:output_type -> queue.v1.EnqueueResponse
+	9,  // 19: queue.v1.QueueService.EnqueueBatch:output_type -> queue.v1.EnqueueBatchResponse
+	13, // 20: queue.v1.QueueService.Dequeue:output_type -> queue.v1.DequeueResponse
+	15, // 21: queue.v1.QueueService.Ack:output_type -> queue.v1.AckResponse
+	17, // 22: queue.v1.QueueService.Nack:output_type -> queue.v1.NackResponse
+	19, // 23: queue.v1.QueueService.Peek:output_type -> queue.v1.PeekResponse
+	21, // 24: queue.v1.QueueService.Renew:output_type -> queue.v1.RenewResponse
+	23, // 25: queue.v1.QueueService.Status:output_type -> queue.v1.StatusResponse
+	15, // [15:26] is the sub-list for method output_type
+	4,  // [4:15] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_proto_queue_proto_init() }
@@ -1506,7 +1600,7 @@ func file_proto_queue_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_queue_proto_rawDesc), len(file_proto_queue_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   24,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/api/grpc/server.go
+++ b/internal/api/grpc/server.go
@@ -184,8 +184,9 @@ func (qs *queueServiceServer) EnqueueBatch(ctx context.Context, req *EnqueueBatc
 						})
 					}
 				}
+				totalSuccess += successCount
 			} else {
-				totalSuccess += int64(successCount)
+				totalSuccess += successCount
 			}
 		}
 		return &EnqueueBatchResponse{

--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -29,9 +29,13 @@ func (m *mockQueue) DeleteQueue(string) error { return nil }
 
 func (m *mockQueue) Enqueue(string, interface{}) error { return nil }
 
-func (m *mockQueue) EnqueueBatch(queueName string, items []interface{}) (int64, error) {
+func (m *mockQueue) EnqueueBatch(queueName, mode string, items []interface{}) (internal.BatchResult, error) {
 	m.enqueueBatchCalls = append(m.enqueueBatchCalls, enqueueBatchCall{queueName: queueName, items: items})
-	return m.enqueueBatchResult, m.enqueueBatchError
+	return internal.BatchResult{
+		SuccessCount:   m.enqueueBatchResult,
+		FailedCount:    0,
+		FailedMessages: nil,
+	}, m.enqueueBatchError
 }
 
 func (m *mockQueue) Dequeue(string, string, string) (internal.QueueMessage, error) {
@@ -69,8 +73,8 @@ func TestQueueServiceEnqueueBatchSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("enqueue batch returned error: %v", err)
 	}
-	if resp.GetStatus() != "enqueued" {
-		t.Fatalf("response status = %s, want enqueued", resp.GetStatus())
+	if resp.GetStatus() != "ok" {
+		t.Fatalf("response status = %s, want ok", resp.GetStatus())
 	}
 
 	if resp.GetQueueName() != "test-queue" {

--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -3,8 +3,8 @@ package grpc
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
-	"os"
 	"reflect"
 	"testing"
 
@@ -14,13 +14,15 @@ import (
 
 type enqueueBatchCall struct {
 	queueName string
+	mode      string
 	items     []interface{}
 }
 
 type mockQueue struct {
-	enqueueBatchResult int64
-	enqueueBatchError  error
-	enqueueBatchCalls  []enqueueBatchCall
+	enqueueBatchResult   int64
+	enqueueBatchError    error
+	enqueueBatchCalls    []enqueueBatchCall
+	enqueueBatchResponse *internal.BatchResult
 }
 
 func (m *mockQueue) CreateQueue(string) error { return nil }
@@ -30,7 +32,10 @@ func (m *mockQueue) DeleteQueue(string) error { return nil }
 func (m *mockQueue) Enqueue(string, interface{}) error { return nil }
 
 func (m *mockQueue) EnqueueBatch(queueName, mode string, items []interface{}) (internal.BatchResult, error) {
-	m.enqueueBatchCalls = append(m.enqueueBatchCalls, enqueueBatchCall{queueName: queueName, items: items})
+	m.enqueueBatchCalls = append(m.enqueueBatchCalls, enqueueBatchCall{queueName: queueName, mode: mode, items: items})
+	if m.enqueueBatchResponse != nil {
+		return *m.enqueueBatchResponse, m.enqueueBatchError
+	}
 	return internal.BatchResult{
 		SuccessCount:   m.enqueueBatchResult,
 		FailedCount:    0,
@@ -58,10 +63,14 @@ func (m *mockQueue) Peek(string, string) (internal.QueueMessage, error) {
 
 func (m *mockQueue) Renew(string, string, int64, string, int) error { return nil }
 
+func newTestGRPCServer(queue internal.Queue) *queueServiceServer {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewQueueServiceServer(queue, logger)
+}
+
 func TestQueueServiceEnqueueBatchSuccess(t *testing.T) {
 	mq := &mockQueue{enqueueBatchResult: 2}
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	server := NewQueueServiceServer(mq, logger)
+	server := newTestGRPCServer(mq)
 
 	req := &EnqueueBatchRequest{
 		QueueName: "test-queue",
@@ -92,16 +101,58 @@ func TestQueueServiceEnqueueBatchSuccess(t *testing.T) {
 	if call.queueName != "test-queue" {
 		t.Fatalf("queue name = %s, want test-queue", call.queueName)
 	}
+	if call.mode != "stopOnFailure" {
+		t.Fatalf("mode = %s, want stopOnFailure", call.mode)
+	}
 	expectedItems := []interface{}{"first", "second"}
 	if !reflect.DeepEqual(call.items, expectedItems) {
 		t.Fatalf("enqueue items = %#v, want %#v", call.items, expectedItems)
 	}
 }
 
+func TestQueueServiceEnqueueBatchPartialSuccess(t *testing.T) {
+	mq := &mockQueue{
+		enqueueBatchResponse: &internal.BatchResult{
+			SuccessCount: 1,
+			FailedCount:  1,
+			FailedMessages: []internal.FailedMessage{
+				{Index: 2, Message: "bad", Reason: "duplicate"},
+			},
+		},
+	}
+	server := newTestGRPCServer(mq)
+
+	req := &EnqueueBatchRequest{
+		QueueName: "test-queue",
+		Mode:      "partialSuccess",
+		Messages:  []string{"first", "second", "third"},
+	}
+
+	resp, err := server.EnqueueBatch(context.Background(), req)
+	if err != nil {
+		t.Fatalf("enqueue batch returned error: %v", err)
+	}
+	if resp.GetFailureCount() != 1 {
+		t.Fatalf("failure count = %d, want 1", resp.GetFailureCount())
+	}
+	if len(resp.GetFailedMessages()) != 1 {
+		t.Fatalf("failed messages = %d, want 1", len(resp.GetFailedMessages()))
+	}
+	fm := resp.GetFailedMessages()[0]
+	if fm.GetIndex() != 2 {
+		t.Fatalf("failed message index = %d, want 2", fm.GetIndex())
+	}
+	if fm.GetMessage() != "bad" {
+		t.Fatalf("failed message payload = %s, want bad", fm.GetMessage())
+	}
+	if fm.GetError() != "duplicate" {
+		t.Fatalf("failed message error = %s, want duplicate", fm.GetError())
+	}
+}
+
 func TestQueueServiceEnqueueBatchMissingQueueName(t *testing.T) {
 	mq := &mockQueue{}
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	server := NewQueueServiceServer(mq, logger)
+	server := newTestGRPCServer(mq)
 
 	req := &EnqueueBatchRequest{QueueName: "", Mode: "stopOnFailure", Messages: []string{"msg"}}
 
@@ -119,8 +170,7 @@ func TestQueueServiceEnqueueBatchMissingQueueName(t *testing.T) {
 
 func TestQueueServiceEnqueueBatchEmptyMessages(t *testing.T) {
 	mq := &mockQueue{}
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	server := NewQueueServiceServer(mq, logger)
+	server := newTestGRPCServer(mq)
 
 	req := &EnqueueBatchRequest{QueueName: "test-queue", Mode: "stopOnFailure", Messages: []string{}}
 
@@ -138,8 +188,7 @@ func TestQueueServiceEnqueueBatchEmptyMessages(t *testing.T) {
 
 func TestQueueServiceEnqueueBatchQueueError(t *testing.T) {
 	mq := &mockQueue{enqueueBatchError: errors.New("boom")}
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	server := NewQueueServiceServer(mq, logger)
+	server := newTestGRPCServer(mq)
 
 	req := &EnqueueBatchRequest{QueueName: "test-queue", Mode: "stopOnFailure", Messages: []string{"msg"}}
 

--- a/internal/api/http/dto.go
+++ b/internal/api/http/dto.go
@@ -18,13 +18,13 @@ type EnqueueBatchRequest struct {
 
 type EnqueueBatchResponse struct {
 	Status         string          `json:"status"`
-	SuccessCount   int             `json:"success_count"`
-	FailureCount   int             `json:"failure_count"`
+	SuccessCount   int64           `json:"success_count"`
+	FailureCount   int64           `json:"failure_count"`
 	FailedMessages []FailedMessage `json:"failed_messages"`
 }
 
 type FailedMessage struct {
-	Index   int    `json:"index"`
+	Index   int64  `json:"index"`
 	Message string `json:"message"`
 	Error   string `json:"error"`
 }

--- a/internal/api/http/dto.go
+++ b/internal/api/http/dto.go
@@ -12,12 +12,21 @@ type EnqueueResponse struct {
 }
 
 type EnqueueBatchRequest struct {
+	Mode     string            `json:"mode" binding:"required,oneof=partialSuccess stopOnFailure"`
 	Messages []json.RawMessage `json:"messages" binding:"required"`
 }
 
 type EnqueueBatchResponse struct {
-	Status       string `json:"status"`
-	SuccessCount int    `json:"success_count"`
+	Status         string          `json:"status"`
+	SuccessCount   int             `json:"success_count"`
+	FailureCount   int             `json:"failure_count"`
+	FailedMessages []FailedMessage `json:"failed_messages"`
+}
+
+type FailedMessage struct {
+	Index   int    `json:"index"`
+	Message string `json:"message"`
+	Error   string `json:"error"`
 }
 
 type DequeueRequest struct {

--- a/internal/api/http/handler.go
+++ b/internal/api/http/handler.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"encoding/json"
 	"errors"
 	"go-msg-queue-mini/internal/queue_error"
 	"net/http"
@@ -123,7 +124,7 @@ func (h *httpServerInstance) enqueueBatchHandler(c *gin.Context) {
 		for i, fm := range batchResult.FailedMessages {
 			resp.FailedMessages[i] = FailedMessage{
 				Index:   fm.Index,
-				Message: fm.Message.(string),
+				Message: string(fm.Message.(json.RawMessage)),
 				Error:   fm.Reason,
 			}
 		}

--- a/internal/api/http/handler.go
+++ b/internal/api/http/handler.go
@@ -163,6 +163,7 @@ func (h *httpServerInstance) enqueueBatchHandler(c *gin.Context) {
 						})
 					}
 				}
+				totalSuccess += successCount
 			} else {
 				totalSuccess += successCount
 			}

--- a/internal/api/http/handler_test.go
+++ b/internal/api/http/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,17 +13,20 @@ import (
 
 	"go-msg-queue-mini/internal"
 	"go-msg-queue-mini/internal/queue_error"
+	"log/slog"
 )
 
 type enqueueBatchCall struct {
 	queueName string
+	mode      string
 	items     []interface{}
 }
 
 type mockQueue struct {
-	enqueueBatchResult int64
-	enqueueBatchError  error
-	enqueueBatchCalls  []enqueueBatchCall
+	enqueueBatchResult   int64
+	enqueueBatchError    error
+	enqueueBatchCalls    []enqueueBatchCall
+	enqueueBatchResponse *internal.BatchResult
 }
 
 func (m *mockQueue) CreateQueue(string) error { return nil }
@@ -32,7 +36,10 @@ func (m *mockQueue) DeleteQueue(string) error { return nil }
 func (m *mockQueue) Enqueue(string, interface{}) error { return nil }
 
 func (m *mockQueue) EnqueueBatch(queueName, mode string, items []interface{}) (internal.BatchResult, error) {
-	m.enqueueBatchCalls = append(m.enqueueBatchCalls, enqueueBatchCall{queueName: queueName, items: items})
+	m.enqueueBatchCalls = append(m.enqueueBatchCalls, enqueueBatchCall{queueName: queueName, mode: mode, items: items})
+	if m.enqueueBatchResponse != nil {
+		return *m.enqueueBatchResponse, m.enqueueBatchError
+	}
 	return internal.BatchResult{
 		SuccessCount:   m.enqueueBatchResult,
 		FailedCount:    0,
@@ -58,10 +65,15 @@ func (m *mockQueue) Peek(string, string) (internal.QueueMessage, error) {
 
 func (m *mockQueue) Renew(string, string, int64, string, int) error { return nil }
 
+func newTestHTTPServer(queue internal.Queue) *httpServerInstance {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return &httpServerInstance{Queue: queue, Logger: logger}
+}
+
 func TestEnqueueBatchHandlerSuccess(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	mq := &mockQueue{enqueueBatchResult: 2}
-	server := &httpServerInstance{Queue: mq}
+	server := newTestHTTPServer(mq)
 
 	body := EnqueueBatchRequest{
 		Mode: "stopOnFailure",
@@ -94,6 +106,9 @@ func TestEnqueueBatchHandlerSuccess(t *testing.T) {
 	call := mq.enqueueBatchCalls[0]
 	if call.queueName != "test-queue" {
 		t.Fatalf("queue name = %s, want test-queue", call.queueName)
+	}
+	if call.mode != "stopOnFailure" {
+		t.Fatalf("mode = %s, want stopOnFailure", call.mode)
 	}
 	expectedItems := []interface{}{
 		json.RawMessage(`{"foo":"bar"}`),
@@ -129,10 +144,71 @@ func TestEnqueueBatchHandlerSuccess(t *testing.T) {
 	}
 }
 
+func TestEnqueueBatchHandlerPartialSuccess(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	failed := []internal.FailedMessage{{Index: 1, Message: json.RawMessage(`"bad"`), Reason: "duplicate message"}}
+	mq := &mockQueue{
+		enqueueBatchResponse: &internal.BatchResult{
+			SuccessCount:   1,
+			FailedCount:    1,
+			FailedMessages: failed,
+		},
+	}
+	server := newTestHTTPServer(mq)
+
+	body := EnqueueBatchRequest{Mode: "partialSuccess", Messages: []json.RawMessage{json.RawMessage(`"good"`), json.RawMessage(`"bad"`)}}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set("queue_name", "partial-queue")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/partial-queue/enqueue/batch", bytes.NewReader(encoded))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	server.enqueueBatchHandler(c)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusAccepted)
+	}
+
+	if len(mq.enqueueBatchCalls) != 1 {
+		t.Fatalf("enqueue batch call count = %d, want 1", len(mq.enqueueBatchCalls))
+	}
+	call := mq.enqueueBatchCalls[0]
+	if call.mode != "partialSuccess" {
+		t.Fatalf("mode = %s, want partialSuccess", call.mode)
+	}
+
+	var resp EnqueueBatchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.FailureCount != 1 {
+		t.Fatalf("failure count = %d, want 1", resp.FailureCount)
+	}
+	if len(resp.FailedMessages) != 1 {
+		t.Fatalf("failed messages = %d, want 1", len(resp.FailedMessages))
+	}
+	fm := resp.FailedMessages[0]
+	if fm.Index != 1 {
+		t.Fatalf("failed message index = %d, want 1", fm.Index)
+	}
+	if fm.Message != "\"bad\"" {
+		t.Fatalf("failed message payload = %s, want \"bad\"", fm.Message)
+	}
+	if fm.Error != "duplicate message" {
+		t.Fatalf("failed message error = %s, want duplicate message", fm.Error)
+	}
+}
+
 func TestEnqueueBatchHandlerBindError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	mq := &mockQueue{}
-	server := &httpServerInstance{Queue: mq}
+	server := newTestHTTPServer(mq)
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -154,7 +230,7 @@ func TestEnqueueBatchHandlerBindError(t *testing.T) {
 func TestEnqueueBatchHandlerQueueError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	mq := &mockQueue{enqueueBatchError: errors.New("boom")}
-	server := &httpServerInstance{Queue: mq}
+	server := newTestHTTPServer(mq)
 
 	body := EnqueueBatchRequest{Mode: "stopOnFailure", Messages: []json.RawMessage{json.RawMessage(`"msg"`)}}
 	encoded, err := json.Marshal(body)

--- a/internal/api/http/handler_test.go
+++ b/internal/api/http/handler_test.go
@@ -31,9 +31,13 @@ func (m *mockQueue) DeleteQueue(string) error { return nil }
 
 func (m *mockQueue) Enqueue(string, interface{}) error { return nil }
 
-func (m *mockQueue) EnqueueBatch(queueName string, items []interface{}) (int64, error) {
+func (m *mockQueue) EnqueueBatch(queueName, mode string, items []interface{}) (internal.BatchResult, error) {
 	m.enqueueBatchCalls = append(m.enqueueBatchCalls, enqueueBatchCall{queueName: queueName, items: items})
-	return m.enqueueBatchResult, m.enqueueBatchError
+	return internal.BatchResult{
+		SuccessCount:   m.enqueueBatchResult,
+		FailedCount:    0,
+		FailedMessages: nil,
+	}, m.enqueueBatchError
 }
 
 func (m *mockQueue) Dequeue(string, string, string) (internal.QueueMessage, error) {

--- a/internal/core/filedb_queue.go
+++ b/internal/core/filedb_queue.go
@@ -109,8 +109,8 @@ func (q *fileDBQueue) Enqueue(queue_name string, item interface{}) error {
 	return nil
 }
 
-func (q *fileDBQueue) EnqueueBatch(queue_name string, items []interface{}) (int, error) {
-	successCount := 0
+func (q *fileDBQueue) EnqueueBatch(queue_name string, items []interface{}) (int64, error) {
+	var successCount int64 = 0
 	msgs := make([][]byte, 0, len(items))
 	for _, item := range items {
 		msg, err := json.Marshal(item)

--- a/internal/core/filedb_queue_test.go
+++ b/internal/core/filedb_queue_test.go
@@ -38,14 +38,14 @@ func TestFileDBQueueEnqueueBatchSuccess(t *testing.T) {
 	if err := queue.CreateQueue(queueName); err != nil {
 		t.Fatalf("failed to create queue: %v", err)
 	}
-
+	mode := "stopOnFailure"
 	batch := []interface{}{"first", map[string]interface{}{"foo": "bar"}}
-	successCount, err := queue.EnqueueBatch(queueName, batch)
+	batchResult, err := queue.EnqueueBatch(queueName, mode, batch)
 	if err != nil {
 		t.Fatalf("enqueue batch returned error: %v", err)
 	}
-	if successCount != int64(len(batch)) {
-		t.Fatalf("enqueue batch success count = %d, want %d", successCount, int64(len(batch)))
+	if batchResult.SuccessCount != int64(len(batch)) {
+		t.Fatalf("enqueue batch success count = %d, want %d", batchResult.SuccessCount, int64(len(batch)))
 	}
 
 	expected := []interface{}{"first", map[string]interface{}{"foo": "bar"}}
@@ -78,14 +78,14 @@ func TestFileDBQueueEnqueueBatchQueueNotFound(t *testing.T) {
 			t.Fatalf("failed to shutdown queue: %v", shutdownErr)
 		}
 	}()
-
+	mode := "stopOnFailure"
 	batch := []interface{}{"no-queue"}
-	successCount, err := queue.EnqueueBatch("missing-queue", batch)
+	batchResult, err := queue.EnqueueBatch("missing-queue", mode, batch)
 	if err == nil {
 		t.Fatal("expected error when enqueueing to missing queue, got nil")
 	}
-	if successCount != 0 {
-		t.Fatalf("success count = %d, want 0", successCount)
+	if batchResult.SuccessCount != 0 {
+		t.Fatalf("success count = %d, want 0", batchResult.SuccessCount)
 	}
 	if !strings.Contains(err.Error(), "queue not found") {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/core/filedb_queue_test.go
+++ b/internal/core/filedb_queue_test.go
@@ -44,8 +44,8 @@ func TestFileDBQueueEnqueueBatchSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("enqueue batch returned error: %v", err)
 	}
-	if successCount != len(batch) {
-		t.Fatalf("enqueue batch success count = %d, want %d", successCount, len(batch))
+	if successCount != int64(len(batch)) {
+		t.Fatalf("enqueue batch success count = %d, want %d", successCount, int64(len(batch)))
 	}
 
 	expected := []interface{}{"first", map[string]interface{}{"foo": "bar"}}

--- a/internal/core/filedb_queue_test.go
+++ b/internal/core/filedb_queue_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"reflect"
@@ -22,22 +23,33 @@ func newTestConfig() *internal.Config {
 	return cfg
 }
 
-func TestFileDBQueueEnqueueBatchSuccess(t *testing.T) {
+func newTestQueue(t *testing.T) *fileDBQueue {
+	t.Helper()
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	queue, err := NewFileDBQueue(newTestConfig(), logger)
 	if err != nil {
 		t.Fatalf("failed to create filedb queue: %v", err)
 	}
-	defer func() {
+	t.Cleanup(func() {
 		if shutdownErr := queue.Shutdown(); shutdownErr != nil {
 			t.Fatalf("failed to shutdown queue: %v", shutdownErr)
 		}
-	}()
+	})
+	return queue
+}
 
-	queueName := "enqueue-batch-success"
+func createQueueOrFail(t *testing.T, queue *fileDBQueue, queueName string) {
+	t.Helper()
 	if err := queue.CreateQueue(queueName); err != nil {
 		t.Fatalf("failed to create queue: %v", err)
 	}
+}
+
+func TestFileDBQueueEnqueueBatchSuccess(t *testing.T) {
+	queue := newTestQueue(t)
+	queueName := "enqueue-batch-success"
+	createQueueOrFail(t, queue, queueName)
+
 	mode := "stopOnFailure"
 	batch := []interface{}{"first", map[string]interface{}{"foo": "bar"}}
 	batchResult, err := queue.EnqueueBatch(queueName, mode, batch)
@@ -68,16 +80,7 @@ func TestFileDBQueueEnqueueBatchSuccess(t *testing.T) {
 }
 
 func TestFileDBQueueEnqueueBatchQueueNotFound(t *testing.T) {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	queue, err := NewFileDBQueue(newTestConfig(), logger)
-	if err != nil {
-		t.Fatalf("failed to create filedb queue: %v", err)
-	}
-	defer func() {
-		if shutdownErr := queue.Shutdown(); shutdownErr != nil {
-			t.Fatalf("failed to shutdown queue: %v", shutdownErr)
-		}
-	}()
+	queue := newTestQueue(t)
 	mode := "stopOnFailure"
 	batch := []interface{}{"no-queue"}
 	batchResult, err := queue.EnqueueBatch("missing-queue", mode, batch)
@@ -89,5 +92,83 @@ func TestFileDBQueueEnqueueBatchQueueNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "queue not found") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFileDBQueueEnqueueBatchStopOnFailureMarshalError(t *testing.T) {
+	queue := newTestQueue(t)
+	queueName := "enqueue-batch-stop-on-failure-marshal-error"
+	createQueueOrFail(t, queue, queueName)
+
+	invalid := make(chan int)
+	batch := []interface{}{"valid", invalid}
+
+	result, err := queue.EnqueueBatch(queueName, "stopOnFailure", batch)
+	if err == nil {
+		t.Fatal("expected marshal error, got nil")
+	}
+	if !strings.Contains(err.Error(), "json: unsupported type: chan int") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.SuccessCount != 0 {
+		t.Fatalf("success count = %d, want 0", result.SuccessCount)
+	}
+	if result.FailedCount != int64(len(batch)) {
+		t.Fatalf("failed count = %d, want %d", result.FailedCount, len(batch))
+	}
+	if len(result.FailedMessages) != 0 {
+		t.Fatalf("expected no failed messages details, got %d", len(result.FailedMessages))
+	}
+
+	if _, err := queue.Dequeue(queueName, "group-stop", "consumer-stop"); !errors.Is(err, queue_error.ErrEmpty) {
+		t.Fatalf("expected empty queue after failure, got %v", err)
+	}
+}
+
+func TestFileDBQueueEnqueueBatchPartialSuccessChunkError(t *testing.T) {
+	queue := newTestQueue(t)
+	queueName := "enqueue-batch-partial-success-chunk-error"
+	createQueueOrFail(t, queue, queueName)
+
+	items := make([]interface{}, 101)
+	for i := 0; i < 100; i++ {
+		items[i] = fmt.Sprintf("msg-%03d", i)
+	}
+	items[100] = make(chan int)
+
+	result, err := queue.EnqueueBatch(queueName, "partialSuccess", items)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if result.SuccessCount != 100 {
+		t.Fatalf("success count = %d, want 100", result.SuccessCount)
+	}
+	if result.FailedCount != 1 {
+		t.Fatalf("failed count = %d, want 1", result.FailedCount)
+	}
+	if len(result.FailedMessages) != 0 {
+		t.Fatalf("expected no failed message details, got %d", len(result.FailedMessages))
+	}
+
+	for i := 0; i < 100; i++ {
+		msg, err := queue.Dequeue(queueName, "group-partial", "consumer-partial")
+		if err != nil {
+			t.Fatalf("dequeue failed at index %d: %v", i, err)
+		}
+		want := fmt.Sprintf("msg-%03d", i)
+		payload, ok := msg.Payload.(string)
+		if !ok {
+			t.Fatalf("expected payload to be string, got %T", msg.Payload)
+		}
+		if payload != want {
+			t.Fatalf("payload = %s, want %s", payload, want)
+		}
+		if ackErr := queue.Ack(queueName, "group-partial", msg.ID, msg.Receipt); ackErr != nil {
+			t.Fatalf("ack failed for message %d: %v", i, ackErr)
+		}
+	}
+
+	if _, err := queue.Dequeue(queueName, "group-partial", "consumer-partial"); !errors.Is(err, queue_error.ErrEmpty) {
+		t.Fatalf("expected empty queue after draining, got %v", err)
 	}
 }

--- a/internal/queue.go
+++ b/internal/queue.go
@@ -20,7 +20,7 @@ type Queue interface {
 	CreateQueue(queue_name string) error
 	DeleteQueue(queue_name string) error
 	Enqueue(queue_name string, item interface{}) error
-	EnqueueBatch(queue_name string, items []interface{}) (int, error)
+	EnqueueBatch(queue_name string, items []interface{}) (int64, error)
 	Dequeue(queue_name string, group_name string, consumer_id string) (QueueMessage, error)
 	Ack(queue_name string, group_name string, messageID int64, receipt string) error
 	Nack(queue_name string, group_name string, messageID int64, receipt string) error

--- a/internal/queue.go
+++ b/internal/queue.go
@@ -15,12 +15,24 @@ type QueueMessage struct {
 	Receipt string
 }
 
+type BatchResult struct {
+	SuccessCount   int64
+	FailedCount    int64
+	FailedMessages []FailedMessage
+}
+
+type FailedMessage struct {
+	Index   int64
+	Message interface{}
+	Reason  string
+}
+
 // add queue_name
 type Queue interface {
 	CreateQueue(queue_name string) error
 	DeleteQueue(queue_name string) error
 	Enqueue(queue_name string, item interface{}) error
-	EnqueueBatch(queue_name string, items []interface{}) (int64, error)
+	EnqueueBatch(queue_name, mode string, items []interface{}) (BatchResult, error)
 	Dequeue(queue_name string, group_name string, consumer_id string) (QueueMessage, error)
 	Ack(queue_name string, group_name string, messageID int64, receipt string) error
 	Nack(queue_name string, group_name string, messageID int64, receipt string) error

--- a/proto/queue.proto
+++ b/proto/queue.proto
@@ -96,7 +96,8 @@ message EnqueueResponse {
 // EnqueueBatch request
 message EnqueueBatchRequest {
   string queue_name = 1;
-  repeated string messages = 2;
+  string mode = 2;
+  repeated string messages = 3;
 }
 
 // EnqueueBatch response
@@ -104,6 +105,15 @@ message EnqueueBatchResponse {
   string status = 1;
   string queue_name = 2;
   int64 success_count = 3;
+  int64 failure_count = 4;
+  repeated FailedMessage failed_messages = 5;
+}
+
+// FailedMessage 
+message FailedMessage {
+  int64 index = 1;
+  string message = 2;
+  string error = 3;
 }
 
 // HTTP: DequeueRequest{ group, consumer_id }

--- a/util/partition.go
+++ b/util/partition.go
@@ -1,0 +1,17 @@
+package util
+
+func ChunkSlice(list []any, chunkSize int) [][]any {
+	if chunkSize <= 0 {
+		return [][]any{list}
+	}
+	var chunks [][]any
+	total := len(list)
+	for i := 0; i < total; i += chunkSize {
+		end := i + chunkSize
+		if end > total {
+			end = total
+		}
+		chunks = append(chunks, list[i:end])
+	}
+	return chunks
+}


### PR DESCRIPTION
- enqueueBatch시 청크 단위로 쪼개서 적용되게끔 로직을 수정
- mode는 StopOnFailure (적용 오류시 멈춤) / PartialSuccess (오류난 청크는 빼고 적용) 2가지를 지원
- http, grpc의 api의 request에 mode 인자값을 추가
- http, grpc의 api의  mode:PartialSuccess일 경우, 오류난 부분의 이유와 해당 메세지를 반환하게끔 response 수정
- enqueueBatch의 successCount를 전체적으로 int -> int64 로 수정