### PR TITLE
Feature/message de duplication

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -20,10 +20,10 @@ func NewQueue(queueName string, queue internal.Queue, logger *slog.Logger) *Queu
 	}
 }
 
-func (qc *QueueClient) Produce(item interface{}, delay string) error {
+func (qc *QueueClient) Produce(item internal.EnqueueMessage) error {
 	// TODO : implement Enqueue logic
 	// If delay is not provided, use default value "0s"
-	if err := qc.Queue.Enqueue(qc.QueueName, item, delay); err != nil {
+	if err := qc.Queue.Enqueue(qc.QueueName, item); err != nil {
 		return err
 	}
 	return nil

--- a/internal/api/grpc/queue.pb.go
+++ b/internal/api/grpc/queue.pb.go
@@ -283,12 +283,13 @@ func (x *DeleteQueueResponse) GetStatus() string {
 
 // HTTP: EnqueueRequest{ message json.RawMessage }
 type EnqueueRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	QueueName     string                 `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
-	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
-	Delay         string                 `protobuf:"bytes,3,opt,name=delay,proto3" json:"delay,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	QueueName       string                 `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
+	Message         string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	Delay           string                 `protobuf:"bytes,3,opt,name=delay,proto3" json:"delay,omitempty"`                                            // optional, e.g., "5s","10m"
+	DeduplicationId string                 `protobuf:"bytes,4,opt,name=deduplication_id,json=deduplicationId,proto3" json:"deduplication_id,omitempty"` // optional
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *EnqueueRequest) Reset() {
@@ -338,6 +339,13 @@ func (x *EnqueueRequest) GetMessage() string {
 func (x *EnqueueRequest) GetDelay() string {
 	if x != nil {
 		return x.Delay
+	}
+	return ""
+}
+
+func (x *EnqueueRequest) GetDeduplicationId() string {
+	if x != nil {
+		return x.DeduplicationId
 	}
 	return ""
 }
@@ -405,13 +413,14 @@ func (x *EnqueueResponse) GetMessage() string {
 
 // EnqueueBatch request
 type EnqueueBatchRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	QueueName     string                 `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
-	Mode          string                 `protobuf:"bytes,2,opt,name=mode,proto3" json:"mode,omitempty"`
-	Messages      []string               `protobuf:"bytes,3,rep,name=messages,proto3" json:"messages,omitempty"`
-	Delay         string                 `protobuf:"bytes,4,opt,name=delay,proto3" json:"delay,omitempty"` // e.g., "10s", "5m"
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	QueueName       string                 `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
+	Mode            string                 `protobuf:"bytes,2,opt,name=mode,proto3" json:"mode,omitempty"`
+	Messages        []string               `protobuf:"bytes,3,rep,name=messages,proto3" json:"messages,omitempty"`
+	Delay           string                 `protobuf:"bytes,4,opt,name=delay,proto3" json:"delay,omitempty"`                                            // optional, e.g., "10s", "5m"
+	DeduplicationId string                 `protobuf:"bytes,5,opt,name=deduplication_id,json=deduplicationId,proto3" json:"deduplication_id,omitempty"` // optional
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *EnqueueBatchRequest) Reset() {
@@ -468,6 +477,13 @@ func (x *EnqueueBatchRequest) GetMessages() []string {
 func (x *EnqueueBatchRequest) GetDelay() string {
 	if x != nil {
 		return x.Delay
+	}
+	return ""
+}
+
+func (x *EnqueueBatchRequest) GetDeduplicationId() string {
+	if x != nil {
+		return x.DeduplicationId
 	}
 	return ""
 }
@@ -1429,23 +1445,25 @@ const file_proto_queue_proto_rawDesc = "" +
 	"\n" +
 	"queue_name\x18\x01 \x01(\tR\tqueueName\"-\n" +
 	"\x13DeleteQueueResponse\x12\x16\n" +
-	"\x06status\x18\x01 \x01(\tR\x06status\"_\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\"\x8a\x01\n" +
 	"\x0eEnqueueRequest\x12\x1d\n" +
 	"\n" +
 	"queue_name\x18\x01 \x01(\tR\tqueueName\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12\x14\n" +
-	"\x05delay\x18\x03 \x01(\tR\x05delay\"b\n" +
+	"\x05delay\x18\x03 \x01(\tR\x05delay\x12)\n" +
+	"\x10deduplication_id\x18\x04 \x01(\tR\x0fdeduplicationId\"b\n" +
 	"\x0fEnqueueResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
 	"\n" +
 	"queue_name\x18\x02 \x01(\tR\tqueueName\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage\"z\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\"\xa5\x01\n" +
 	"\x13EnqueueBatchRequest\x12\x1d\n" +
 	"\n" +
 	"queue_name\x18\x01 \x01(\tR\tqueueName\x12\x12\n" +
 	"\x04mode\x18\x02 \x01(\tR\x04mode\x12\x1a\n" +
 	"\bmessages\x18\x03 \x03(\tR\bmessages\x12\x14\n" +
-	"\x05delay\x18\x04 \x01(\tR\x05delay\"\xd9\x01\n" +
+	"\x05delay\x18\x04 \x01(\tR\x05delay\x12)\n" +
+	"\x10deduplication_id\x18\x05 \x01(\tR\x0fdeduplicationId\"\xd9\x01\n" +
 	"\x14EnqueueBatchResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
 	"\n" +

--- a/internal/api/grpc/queue.pb.go
+++ b/internal/api/grpc/queue.pb.go
@@ -283,13 +283,11 @@ func (x *DeleteQueueResponse) GetStatus() string {
 
 // HTTP: EnqueueRequest{ message json.RawMessage }
 type EnqueueRequest struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	QueueName       string                 `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
-	Message         string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
-	Delay           string                 `protobuf:"bytes,3,opt,name=delay,proto3" json:"delay,omitempty"`                                            // optional, e.g., "5s","10m"
-	DeduplicationId string                 `protobuf:"bytes,4,opt,name=deduplication_id,json=deduplicationId,proto3" json:"deduplication_id,omitempty"` // optional
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	QueueName     string                 `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
+	Message       *EnqueueMessage        `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *EnqueueRequest) Reset() {
@@ -329,21 +327,67 @@ func (x *EnqueueRequest) GetQueueName() string {
 	return ""
 }
 
-func (x *EnqueueRequest) GetMessage() string {
+func (x *EnqueueRequest) GetMessage() *EnqueueMessage {
+	if x != nil {
+		return x.Message
+	}
+	return nil
+}
+
+type EnqueueMessage struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Message         string                 `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
+	Delay           string                 `protobuf:"bytes,2,opt,name=delay,proto3" json:"delay,omitempty"`                                            // optional, e.g., "5s","10m"
+	DeduplicationId string                 `protobuf:"bytes,3,opt,name=deduplication_id,json=deduplicationId,proto3" json:"deduplication_id,omitempty"` // optional
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *EnqueueMessage) Reset() {
+	*x = EnqueueMessage{}
+	mi := &file_proto_queue_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnqueueMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnqueueMessage) ProtoMessage() {}
+
+func (x *EnqueueMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_queue_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnqueueMessage.ProtoReflect.Descriptor instead.
+func (*EnqueueMessage) Descriptor() ([]byte, []int) {
+	return file_proto_queue_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *EnqueueMessage) GetMessage() string {
 	if x != nil {
 		return x.Message
 	}
 	return ""
 }
 
-func (x *EnqueueRequest) GetDelay() string {
+func (x *EnqueueMessage) GetDelay() string {
 	if x != nil {
 		return x.Delay
 	}
 	return ""
 }
 
-func (x *EnqueueRequest) GetDeduplicationId() string {
+func (x *EnqueueMessage) GetDeduplicationId() string {
 	if x != nil {
 		return x.DeduplicationId
 	}
@@ -362,7 +406,7 @@ type EnqueueResponse struct {
 
 func (x *EnqueueResponse) Reset() {
 	*x = EnqueueResponse{}
-	mi := &file_proto_queue_proto_msgTypes[7]
+	mi := &file_proto_queue_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -374,7 +418,7 @@ func (x *EnqueueResponse) String() string {
 func (*EnqueueResponse) ProtoMessage() {}
 
 func (x *EnqueueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[7]
+	mi := &file_proto_queue_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -387,7 +431,7 @@ func (x *EnqueueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnqueueResponse.ProtoReflect.Descriptor instead.
 func (*EnqueueResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{7}
+	return file_proto_queue_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *EnqueueResponse) GetStatus() string {
@@ -413,19 +457,17 @@ func (x *EnqueueResponse) GetMessage() string {
 
 // EnqueueBatch request
 type EnqueueBatchRequest struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	QueueName       string                 `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
-	Mode            string                 `protobuf:"bytes,2,opt,name=mode,proto3" json:"mode,omitempty"`
-	Messages        []string               `protobuf:"bytes,3,rep,name=messages,proto3" json:"messages,omitempty"`
-	Delay           string                 `protobuf:"bytes,4,opt,name=delay,proto3" json:"delay,omitempty"`                                            // optional, e.g., "10s", "5m"
-	DeduplicationId string                 `protobuf:"bytes,5,opt,name=deduplication_id,json=deduplicationId,proto3" json:"deduplication_id,omitempty"` // optional
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	QueueName     string                 `protobuf:"bytes,1,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
+	Mode          string                 `protobuf:"bytes,2,opt,name=mode,proto3" json:"mode,omitempty"`
+	Messages      []*EnqueueMessage      `protobuf:"bytes,3,rep,name=messages,proto3" json:"messages,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *EnqueueBatchRequest) Reset() {
 	*x = EnqueueBatchRequest{}
-	mi := &file_proto_queue_proto_msgTypes[8]
+	mi := &file_proto_queue_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -437,7 +479,7 @@ func (x *EnqueueBatchRequest) String() string {
 func (*EnqueueBatchRequest) ProtoMessage() {}
 
 func (x *EnqueueBatchRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[8]
+	mi := &file_proto_queue_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -450,7 +492,7 @@ func (x *EnqueueBatchRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnqueueBatchRequest.ProtoReflect.Descriptor instead.
 func (*EnqueueBatchRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{8}
+	return file_proto_queue_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *EnqueueBatchRequest) GetQueueName() string {
@@ -467,25 +509,11 @@ func (x *EnqueueBatchRequest) GetMode() string {
 	return ""
 }
 
-func (x *EnqueueBatchRequest) GetMessages() []string {
+func (x *EnqueueBatchRequest) GetMessages() []*EnqueueMessage {
 	if x != nil {
 		return x.Messages
 	}
 	return nil
-}
-
-func (x *EnqueueBatchRequest) GetDelay() string {
-	if x != nil {
-		return x.Delay
-	}
-	return ""
-}
-
-func (x *EnqueueBatchRequest) GetDeduplicationId() string {
-	if x != nil {
-		return x.DeduplicationId
-	}
-	return ""
 }
 
 // EnqueueBatch response
@@ -502,7 +530,7 @@ type EnqueueBatchResponse struct {
 
 func (x *EnqueueBatchResponse) Reset() {
 	*x = EnqueueBatchResponse{}
-	mi := &file_proto_queue_proto_msgTypes[9]
+	mi := &file_proto_queue_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -514,7 +542,7 @@ func (x *EnqueueBatchResponse) String() string {
 func (*EnqueueBatchResponse) ProtoMessage() {}
 
 func (x *EnqueueBatchResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[9]
+	mi := &file_proto_queue_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -527,7 +555,7 @@ func (x *EnqueueBatchResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnqueueBatchResponse.ProtoReflect.Descriptor instead.
 func (*EnqueueBatchResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{9}
+	return file_proto_queue_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *EnqueueBatchResponse) GetStatus() string {
@@ -577,7 +605,7 @@ type FailedMessage struct {
 
 func (x *FailedMessage) Reset() {
 	*x = FailedMessage{}
-	mi := &file_proto_queue_proto_msgTypes[10]
+	mi := &file_proto_queue_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -589,7 +617,7 @@ func (x *FailedMessage) String() string {
 func (*FailedMessage) ProtoMessage() {}
 
 func (x *FailedMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[10]
+	mi := &file_proto_queue_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -602,7 +630,7 @@ func (x *FailedMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FailedMessage.ProtoReflect.Descriptor instead.
 func (*FailedMessage) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{10}
+	return file_proto_queue_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *FailedMessage) GetIndex() int64 {
@@ -638,7 +666,7 @@ type DequeueRequest struct {
 
 func (x *DequeueRequest) Reset() {
 	*x = DequeueRequest{}
-	mi := &file_proto_queue_proto_msgTypes[11]
+	mi := &file_proto_queue_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -650,7 +678,7 @@ func (x *DequeueRequest) String() string {
 func (*DequeueRequest) ProtoMessage() {}
 
 func (x *DequeueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[11]
+	mi := &file_proto_queue_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -663,7 +691,7 @@ func (x *DequeueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DequeueRequest.ProtoReflect.Descriptor instead.
 func (*DequeueRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{11}
+	return file_proto_queue_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *DequeueRequest) GetQueueName() string {
@@ -699,7 +727,7 @@ type DequeueMessage struct {
 
 func (x *DequeueMessage) Reset() {
 	*x = DequeueMessage{}
-	mi := &file_proto_queue_proto_msgTypes[12]
+	mi := &file_proto_queue_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -711,7 +739,7 @@ func (x *DequeueMessage) String() string {
 func (*DequeueMessage) ProtoMessage() {}
 
 func (x *DequeueMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[12]
+	mi := &file_proto_queue_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -724,7 +752,7 @@ func (x *DequeueMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DequeueMessage.ProtoReflect.Descriptor instead.
 func (*DequeueMessage) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{12}
+	return file_proto_queue_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DequeueMessage) GetPayload() string {
@@ -759,7 +787,7 @@ type DequeueResponse struct {
 
 func (x *DequeueResponse) Reset() {
 	*x = DequeueResponse{}
-	mi := &file_proto_queue_proto_msgTypes[13]
+	mi := &file_proto_queue_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -771,7 +799,7 @@ func (x *DequeueResponse) String() string {
 func (*DequeueResponse) ProtoMessage() {}
 
 func (x *DequeueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[13]
+	mi := &file_proto_queue_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -784,7 +812,7 @@ func (x *DequeueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DequeueResponse.ProtoReflect.Descriptor instead.
 func (*DequeueResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{13}
+	return file_proto_queue_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *DequeueResponse) GetStatus() string {
@@ -814,7 +842,7 @@ type AckRequest struct {
 
 func (x *AckRequest) Reset() {
 	*x = AckRequest{}
-	mi := &file_proto_queue_proto_msgTypes[14]
+	mi := &file_proto_queue_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -826,7 +854,7 @@ func (x *AckRequest) String() string {
 func (*AckRequest) ProtoMessage() {}
 
 func (x *AckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[14]
+	mi := &file_proto_queue_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -839,7 +867,7 @@ func (x *AckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AckRequest.ProtoReflect.Descriptor instead.
 func (*AckRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{14}
+	return file_proto_queue_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *AckRequest) GetQueueName() string {
@@ -879,7 +907,7 @@ type AckResponse struct {
 
 func (x *AckResponse) Reset() {
 	*x = AckResponse{}
-	mi := &file_proto_queue_proto_msgTypes[15]
+	mi := &file_proto_queue_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -891,7 +919,7 @@ func (x *AckResponse) String() string {
 func (*AckResponse) ProtoMessage() {}
 
 func (x *AckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[15]
+	mi := &file_proto_queue_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -904,7 +932,7 @@ func (x *AckResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AckResponse.ProtoReflect.Descriptor instead.
 func (*AckResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{15}
+	return file_proto_queue_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *AckResponse) GetStatus() string {
@@ -927,7 +955,7 @@ type NackRequest struct {
 
 func (x *NackRequest) Reset() {
 	*x = NackRequest{}
-	mi := &file_proto_queue_proto_msgTypes[16]
+	mi := &file_proto_queue_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -939,7 +967,7 @@ func (x *NackRequest) String() string {
 func (*NackRequest) ProtoMessage() {}
 
 func (x *NackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[16]
+	mi := &file_proto_queue_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -952,7 +980,7 @@ func (x *NackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NackRequest.ProtoReflect.Descriptor instead.
 func (*NackRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{16}
+	return file_proto_queue_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *NackRequest) GetQueueName() string {
@@ -992,7 +1020,7 @@ type NackResponse struct {
 
 func (x *NackResponse) Reset() {
 	*x = NackResponse{}
-	mi := &file_proto_queue_proto_msgTypes[17]
+	mi := &file_proto_queue_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1004,7 +1032,7 @@ func (x *NackResponse) String() string {
 func (*NackResponse) ProtoMessage() {}
 
 func (x *NackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[17]
+	mi := &file_proto_queue_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1017,7 +1045,7 @@ func (x *NackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NackResponse.ProtoReflect.Descriptor instead.
 func (*NackResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{17}
+	return file_proto_queue_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *NackResponse) GetStatus() string {
@@ -1038,7 +1066,7 @@ type PeekRequest struct {
 
 func (x *PeekRequest) Reset() {
 	*x = PeekRequest{}
-	mi := &file_proto_queue_proto_msgTypes[18]
+	mi := &file_proto_queue_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1050,7 +1078,7 @@ func (x *PeekRequest) String() string {
 func (*PeekRequest) ProtoMessage() {}
 
 func (x *PeekRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[18]
+	mi := &file_proto_queue_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1063,7 +1091,7 @@ func (x *PeekRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PeekRequest.ProtoReflect.Descriptor instead.
 func (*PeekRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{18}
+	return file_proto_queue_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *PeekRequest) GetQueueName() string {
@@ -1091,7 +1119,7 @@ type PeekResponse struct {
 
 func (x *PeekResponse) Reset() {
 	*x = PeekResponse{}
-	mi := &file_proto_queue_proto_msgTypes[19]
+	mi := &file_proto_queue_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1103,7 +1131,7 @@ func (x *PeekResponse) String() string {
 func (*PeekResponse) ProtoMessage() {}
 
 func (x *PeekResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[19]
+	mi := &file_proto_queue_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1116,7 +1144,7 @@ func (x *PeekResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PeekResponse.ProtoReflect.Descriptor instead.
 func (*PeekResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{19}
+	return file_proto_queue_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *PeekResponse) GetStatus() string {
@@ -1147,7 +1175,7 @@ type RenewRequest struct {
 
 func (x *RenewRequest) Reset() {
 	*x = RenewRequest{}
-	mi := &file_proto_queue_proto_msgTypes[20]
+	mi := &file_proto_queue_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1159,7 +1187,7 @@ func (x *RenewRequest) String() string {
 func (*RenewRequest) ProtoMessage() {}
 
 func (x *RenewRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[20]
+	mi := &file_proto_queue_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1172,7 +1200,7 @@ func (x *RenewRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewRequest.ProtoReflect.Descriptor instead.
 func (*RenewRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{20}
+	return file_proto_queue_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *RenewRequest) GetQueueName() string {
@@ -1219,7 +1247,7 @@ type RenewResponse struct {
 
 func (x *RenewResponse) Reset() {
 	*x = RenewResponse{}
-	mi := &file_proto_queue_proto_msgTypes[21]
+	mi := &file_proto_queue_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1231,7 +1259,7 @@ func (x *RenewResponse) String() string {
 func (*RenewResponse) ProtoMessage() {}
 
 func (x *RenewResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[21]
+	mi := &file_proto_queue_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1244,7 +1272,7 @@ func (x *RenewResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenewResponse.ProtoReflect.Descriptor instead.
 func (*RenewResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{21}
+	return file_proto_queue_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *RenewResponse) GetStatus() string {
@@ -1263,7 +1291,7 @@ type StatusRequest struct {
 
 func (x *StatusRequest) Reset() {
 	*x = StatusRequest{}
-	mi := &file_proto_queue_proto_msgTypes[22]
+	mi := &file_proto_queue_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1275,7 +1303,7 @@ func (x *StatusRequest) String() string {
 func (*StatusRequest) ProtoMessage() {}
 
 func (x *StatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[22]
+	mi := &file_proto_queue_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1288,7 +1316,7 @@ func (x *StatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusRequest.ProtoReflect.Descriptor instead.
 func (*StatusRequest) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{22}
+	return file_proto_queue_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *StatusRequest) GetQueueName() string {
@@ -1309,7 +1337,7 @@ type StatusResponse struct {
 
 func (x *StatusResponse) Reset() {
 	*x = StatusResponse{}
-	mi := &file_proto_queue_proto_msgTypes[23]
+	mi := &file_proto_queue_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1321,7 +1349,7 @@ func (x *StatusResponse) String() string {
 func (*StatusResponse) ProtoMessage() {}
 
 func (x *StatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[23]
+	mi := &file_proto_queue_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1334,7 +1362,7 @@ func (x *StatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StatusResponse.ProtoReflect.Descriptor instead.
 func (*StatusResponse) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{23}
+	return file_proto_queue_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *StatusResponse) GetStatus() string {
@@ -1365,7 +1393,7 @@ type QueueStatus struct {
 
 func (x *QueueStatus) Reset() {
 	*x = QueueStatus{}
-	mi := &file_proto_queue_proto_msgTypes[24]
+	mi := &file_proto_queue_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1377,7 +1405,7 @@ func (x *QueueStatus) String() string {
 func (*QueueStatus) ProtoMessage() {}
 
 func (x *QueueStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_queue_proto_msgTypes[24]
+	mi := &file_proto_queue_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1390,7 +1418,7 @@ func (x *QueueStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueueStatus.ProtoReflect.Descriptor instead.
 func (*QueueStatus) Descriptor() ([]byte, []int) {
-	return file_proto_queue_proto_rawDescGZIP(), []int{24}
+	return file_proto_queue_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *QueueStatus) GetQueueName() string {
@@ -1445,25 +1473,25 @@ const file_proto_queue_proto_rawDesc = "" +
 	"\n" +
 	"queue_name\x18\x01 \x01(\tR\tqueueName\"-\n" +
 	"\x13DeleteQueueResponse\x12\x16\n" +
-	"\x06status\x18\x01 \x01(\tR\x06status\"\x8a\x01\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\"c\n" +
 	"\x0eEnqueueRequest\x12\x1d\n" +
 	"\n" +
-	"queue_name\x18\x01 \x01(\tR\tqueueName\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\x12\x14\n" +
-	"\x05delay\x18\x03 \x01(\tR\x05delay\x12)\n" +
-	"\x10deduplication_id\x18\x04 \x01(\tR\x0fdeduplicationId\"b\n" +
+	"queue_name\x18\x01 \x01(\tR\tqueueName\x122\n" +
+	"\amessage\x18\x02 \x01(\v2\x18.queue.v1.EnqueueMessageR\amessage\"k\n" +
+	"\x0eEnqueueMessage\x12\x18\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\x12\x14\n" +
+	"\x05delay\x18\x02 \x01(\tR\x05delay\x12)\n" +
+	"\x10deduplication_id\x18\x03 \x01(\tR\x0fdeduplicationId\"b\n" +
 	"\x0fEnqueueResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
 	"\n" +
 	"queue_name\x18\x02 \x01(\tR\tqueueName\x12\x18\n" +
-	"\amessage\x18\x03 \x01(\tR\amessage\"\xa5\x01\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\"~\n" +
 	"\x13EnqueueBatchRequest\x12\x1d\n" +
 	"\n" +
 	"queue_name\x18\x01 \x01(\tR\tqueueName\x12\x12\n" +
-	"\x04mode\x18\x02 \x01(\tR\x04mode\x12\x1a\n" +
-	"\bmessages\x18\x03 \x03(\tR\bmessages\x12\x14\n" +
-	"\x05delay\x18\x04 \x01(\tR\x05delay\x12)\n" +
-	"\x10deduplication_id\x18\x05 \x01(\tR\x0fdeduplicationId\"\xd9\x01\n" +
+	"\x04mode\x18\x02 \x01(\tR\x04mode\x124\n" +
+	"\bmessages\x18\x03 \x03(\v2\x18.queue.v1.EnqueueMessageR\bmessages\"\xd9\x01\n" +
 	"\x14EnqueueBatchResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1d\n" +
 	"\n" +
@@ -1563,7 +1591,7 @@ func file_proto_queue_proto_rawDescGZIP() []byte {
 	return file_proto_queue_proto_rawDescData
 }
 
-var file_proto_queue_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_proto_queue_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_proto_queue_proto_goTypes = []any{
 	(*EmptyRequest)(nil),         // 0: queue.v1.EmptyRequest
 	(*HealthResponse)(nil),       // 1: queue.v1.HealthResponse
@@ -1572,57 +1600,60 @@ var file_proto_queue_proto_goTypes = []any{
 	(*DeleteQueueRequest)(nil),   // 4: queue.v1.DeleteQueueRequest
 	(*DeleteQueueResponse)(nil),  // 5: queue.v1.DeleteQueueResponse
 	(*EnqueueRequest)(nil),       // 6: queue.v1.EnqueueRequest
-	(*EnqueueResponse)(nil),      // 7: queue.v1.EnqueueResponse
-	(*EnqueueBatchRequest)(nil),  // 8: queue.v1.EnqueueBatchRequest
-	(*EnqueueBatchResponse)(nil), // 9: queue.v1.EnqueueBatchResponse
-	(*FailedMessage)(nil),        // 10: queue.v1.FailedMessage
-	(*DequeueRequest)(nil),       // 11: queue.v1.DequeueRequest
-	(*DequeueMessage)(nil),       // 12: queue.v1.DequeueMessage
-	(*DequeueResponse)(nil),      // 13: queue.v1.DequeueResponse
-	(*AckRequest)(nil),           // 14: queue.v1.AckRequest
-	(*AckResponse)(nil),          // 15: queue.v1.AckResponse
-	(*NackRequest)(nil),          // 16: queue.v1.NackRequest
-	(*NackResponse)(nil),         // 17: queue.v1.NackResponse
-	(*PeekRequest)(nil),          // 18: queue.v1.PeekRequest
-	(*PeekResponse)(nil),         // 19: queue.v1.PeekResponse
-	(*RenewRequest)(nil),         // 20: queue.v1.RenewRequest
-	(*RenewResponse)(nil),        // 21: queue.v1.RenewResponse
-	(*StatusRequest)(nil),        // 22: queue.v1.StatusRequest
-	(*StatusResponse)(nil),       // 23: queue.v1.StatusResponse
-	(*QueueStatus)(nil),          // 24: queue.v1.QueueStatus
+	(*EnqueueMessage)(nil),       // 7: queue.v1.EnqueueMessage
+	(*EnqueueResponse)(nil),      // 8: queue.v1.EnqueueResponse
+	(*EnqueueBatchRequest)(nil),  // 9: queue.v1.EnqueueBatchRequest
+	(*EnqueueBatchResponse)(nil), // 10: queue.v1.EnqueueBatchResponse
+	(*FailedMessage)(nil),        // 11: queue.v1.FailedMessage
+	(*DequeueRequest)(nil),       // 12: queue.v1.DequeueRequest
+	(*DequeueMessage)(nil),       // 13: queue.v1.DequeueMessage
+	(*DequeueResponse)(nil),      // 14: queue.v1.DequeueResponse
+	(*AckRequest)(nil),           // 15: queue.v1.AckRequest
+	(*AckResponse)(nil),          // 16: queue.v1.AckResponse
+	(*NackRequest)(nil),          // 17: queue.v1.NackRequest
+	(*NackResponse)(nil),         // 18: queue.v1.NackResponse
+	(*PeekRequest)(nil),          // 19: queue.v1.PeekRequest
+	(*PeekResponse)(nil),         // 20: queue.v1.PeekResponse
+	(*RenewRequest)(nil),         // 21: queue.v1.RenewRequest
+	(*RenewResponse)(nil),        // 22: queue.v1.RenewResponse
+	(*StatusRequest)(nil),        // 23: queue.v1.StatusRequest
+	(*StatusResponse)(nil),       // 24: queue.v1.StatusResponse
+	(*QueueStatus)(nil),          // 25: queue.v1.QueueStatus
 }
 var file_proto_queue_proto_depIdxs = []int32{
-	10, // 0: queue.v1.EnqueueBatchResponse.failed_messages:type_name -> queue.v1.FailedMessage
-	12, // 1: queue.v1.DequeueResponse.message:type_name -> queue.v1.DequeueMessage
-	12, // 2: queue.v1.PeekResponse.message:type_name -> queue.v1.DequeueMessage
-	24, // 3: queue.v1.StatusResponse.queue_status:type_name -> queue.v1.QueueStatus
-	0,  // 4: queue.v1.QueueService.HealthCheck:input_type -> queue.v1.EmptyRequest
-	2,  // 5: queue.v1.QueueService.CreateQueue:input_type -> queue.v1.CreateQueueRequest
-	4,  // 6: queue.v1.QueueService.DeleteQueue:input_type -> queue.v1.DeleteQueueRequest
-	6,  // 7: queue.v1.QueueService.Enqueue:input_type -> queue.v1.EnqueueRequest
-	8,  // 8: queue.v1.QueueService.EnqueueBatch:input_type -> queue.v1.EnqueueBatchRequest
-	11, // 9: queue.v1.QueueService.Dequeue:input_type -> queue.v1.DequeueRequest
-	14, // 10: queue.v1.QueueService.Ack:input_type -> queue.v1.AckRequest
-	16, // 11: queue.v1.QueueService.Nack:input_type -> queue.v1.NackRequest
-	18, // 12: queue.v1.QueueService.Peek:input_type -> queue.v1.PeekRequest
-	20, // 13: queue.v1.QueueService.Renew:input_type -> queue.v1.RenewRequest
-	22, // 14: queue.v1.QueueService.Status:input_type -> queue.v1.StatusRequest
-	1,  // 15: queue.v1.QueueService.HealthCheck:output_type -> queue.v1.HealthResponse
-	3,  // 16: queue.v1.QueueService.CreateQueue:output_type -> queue.v1.CreateQueueResponse
-	5,  // 17: queue.v1.QueueService.DeleteQueue:output_type -> queue.v1.DeleteQueueResponse
-	7,  // 18: queue.v1.QueueService.Enqueue:output_type -> queue.v1.EnqueueResponse
-	9,  // 19: queue.v1.QueueService.EnqueueBatch:output_type -> queue.v1.EnqueueBatchResponse
-	13, // 20: queue.v1.QueueService.Dequeue:output_type -> queue.v1.DequeueResponse
-	15, // 21: queue.v1.QueueService.Ack:output_type -> queue.v1.AckResponse
-	17, // 22: queue.v1.QueueService.Nack:output_type -> queue.v1.NackResponse
-	19, // 23: queue.v1.QueueService.Peek:output_type -> queue.v1.PeekResponse
-	21, // 24: queue.v1.QueueService.Renew:output_type -> queue.v1.RenewResponse
-	23, // 25: queue.v1.QueueService.Status:output_type -> queue.v1.StatusResponse
-	15, // [15:26] is the sub-list for method output_type
-	4,  // [4:15] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	7,  // 0: queue.v1.EnqueueRequest.message:type_name -> queue.v1.EnqueueMessage
+	7,  // 1: queue.v1.EnqueueBatchRequest.messages:type_name -> queue.v1.EnqueueMessage
+	11, // 2: queue.v1.EnqueueBatchResponse.failed_messages:type_name -> queue.v1.FailedMessage
+	13, // 3: queue.v1.DequeueResponse.message:type_name -> queue.v1.DequeueMessage
+	13, // 4: queue.v1.PeekResponse.message:type_name -> queue.v1.DequeueMessage
+	25, // 5: queue.v1.StatusResponse.queue_status:type_name -> queue.v1.QueueStatus
+	0,  // 6: queue.v1.QueueService.HealthCheck:input_type -> queue.v1.EmptyRequest
+	2,  // 7: queue.v1.QueueService.CreateQueue:input_type -> queue.v1.CreateQueueRequest
+	4,  // 8: queue.v1.QueueService.DeleteQueue:input_type -> queue.v1.DeleteQueueRequest
+	6,  // 9: queue.v1.QueueService.Enqueue:input_type -> queue.v1.EnqueueRequest
+	9,  // 10: queue.v1.QueueService.EnqueueBatch:input_type -> queue.v1.EnqueueBatchRequest
+	12, // 11: queue.v1.QueueService.Dequeue:input_type -> queue.v1.DequeueRequest
+	15, // 12: queue.v1.QueueService.Ack:input_type -> queue.v1.AckRequest
+	17, // 13: queue.v1.QueueService.Nack:input_type -> queue.v1.NackRequest
+	19, // 14: queue.v1.QueueService.Peek:input_type -> queue.v1.PeekRequest
+	21, // 15: queue.v1.QueueService.Renew:input_type -> queue.v1.RenewRequest
+	23, // 16: queue.v1.QueueService.Status:input_type -> queue.v1.StatusRequest
+	1,  // 17: queue.v1.QueueService.HealthCheck:output_type -> queue.v1.HealthResponse
+	3,  // 18: queue.v1.QueueService.CreateQueue:output_type -> queue.v1.CreateQueueResponse
+	5,  // 19: queue.v1.QueueService.DeleteQueue:output_type -> queue.v1.DeleteQueueResponse
+	8,  // 20: queue.v1.QueueService.Enqueue:output_type -> queue.v1.EnqueueResponse
+	10, // 21: queue.v1.QueueService.EnqueueBatch:output_type -> queue.v1.EnqueueBatchResponse
+	14, // 22: queue.v1.QueueService.Dequeue:output_type -> queue.v1.DequeueResponse
+	16, // 23: queue.v1.QueueService.Ack:output_type -> queue.v1.AckResponse
+	18, // 24: queue.v1.QueueService.Nack:output_type -> queue.v1.NackResponse
+	20, // 25: queue.v1.QueueService.Peek:output_type -> queue.v1.PeekResponse
+	22, // 26: queue.v1.QueueService.Renew:output_type -> queue.v1.RenewResponse
+	24, // 27: queue.v1.QueueService.Status:output_type -> queue.v1.StatusResponse
+	17, // [17:28] is the sub-list for method output_type
+	6,  // [6:17] is the sub-list for method input_type
+	6,  // [6:6] is the sub-list for extension type_name
+	6,  // [6:6] is the sub-list for extension extendee
+	0,  // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_proto_queue_proto_init() }
@@ -1636,7 +1667,7 @@ func file_proto_queue_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_queue_proto_rawDesc), len(file_proto_queue_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   25,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/api/http/dto.go
+++ b/internal/api/http/dto.go
@@ -3,8 +3,9 @@ package http
 import "encoding/json"
 
 type EnqueueRequest struct {
-	Message json.RawMessage `json:"message" binding:"required"`
-	Delay   string          `json:"delay"` // e.g., "10s", "1m"
+	Message         json.RawMessage `json:"message" binding:"required"`
+	Delay           string          `json:"delay"`            // optional, e.g., "10s", "1m"
+	DeduplicationID string          `json:"deduplication_id"` // optional, for FIFO queues
 }
 
 type EnqueueResponse struct {
@@ -13,9 +14,10 @@ type EnqueueResponse struct {
 }
 
 type EnqueueBatchRequest struct {
-	Mode     string            `json:"mode" binding:"required,oneof=partialSuccess stopOnFailure"`
-	Delay    string            `json:"delay"` // e.g., "10s", "1m"
-	Messages []json.RawMessage `json:"messages" binding:"required"`
+	Mode            string            `json:"mode" binding:"required,oneof=partialSuccess stopOnFailure"`
+	Delay           string            `json:"delay"`            // optional, e.g., "10s", "1m"
+	DeduplicationID string            `json:"deduplication_id"` // optional, for FIFO queues
+	Messages        []json.RawMessage `json:"messages" binding:"required"`
 }
 
 type EnqueueBatchResponse struct {

--- a/internal/api/http/dto.go
+++ b/internal/api/http/dto.go
@@ -14,10 +14,14 @@ type EnqueueResponse struct {
 }
 
 type EnqueueBatchRequest struct {
-	Mode            string            `json:"mode" binding:"required,oneof=partialSuccess stopOnFailure"`
-	Delay           string            `json:"delay"`            // optional, e.g., "10s", "1m"
-	DeduplicationID string            `json:"deduplication_id"` // optional, for FIFO queues
-	Messages        []json.RawMessage `json:"messages" binding:"required"`
+	Mode     string           `json:"mode" binding:"required,oneof=partialSuccess stopOnFailure"`
+	Messages []EnqueueMessage `json:"messages" binding:"required,dive,required"`
+}
+
+type EnqueueMessage struct {
+	Message         json.RawMessage `json:"message"`
+	Delay           string          `json:"delay"`
+	DeduplicationID string          `json:"deduplication_id"`
 }
 
 type EnqueueBatchResponse struct {

--- a/internal/api/http/handler_test.go
+++ b/internal/api/http/handler_test.go
@@ -19,8 +19,7 @@ import (
 type enqueueBatchCall struct {
 	queueName string
 	mode      string
-	delay     string
-	items     []interface{}
+	items     []internal.EnqueueMessage
 }
 
 type mockQueue struct {
@@ -34,10 +33,10 @@ func (m *mockQueue) CreateQueue(string) error { return nil }
 
 func (m *mockQueue) DeleteQueue(string) error { return nil }
 
-func (m *mockQueue) Enqueue(string, interface{}, string) error { return nil }
+func (m *mockQueue) Enqueue(string, internal.EnqueueMessage) error { return nil }
 
-func (m *mockQueue) EnqueueBatch(queueName, mode, delay string, items []interface{}) (internal.BatchResult, error) {
-	m.enqueueBatchCalls = append(m.enqueueBatchCalls, enqueueBatchCall{queueName: queueName, mode: mode, delay: delay, items: items})
+func (m *mockQueue) EnqueueBatch(queueName, mode string, items []internal.EnqueueMessage) (internal.BatchResult, error) {
+	m.enqueueBatchCalls = append(m.enqueueBatchCalls, enqueueBatchCall{queueName: queueName, mode: mode, items: items})
 	if m.enqueueBatchResponse != nil {
 		return *m.enqueueBatchResponse, m.enqueueBatchError
 	}
@@ -78,9 +77,9 @@ func TestEnqueueBatchHandlerSuccess(t *testing.T) {
 
 	body := EnqueueBatchRequest{
 		Mode: "stopOnFailure",
-		Messages: []json.RawMessage{
-			json.RawMessage(`{"foo":"bar"}`),
-			json.RawMessage(`42`),
+		Messages: []EnqueueMessage{
+			{Message: json.RawMessage(`{"foo":"bar"}`)},
+			{Message: json.RawMessage(`42`)},
 		},
 	}
 	encoded, err := json.Marshal(body)
@@ -111,29 +110,32 @@ func TestEnqueueBatchHandlerSuccess(t *testing.T) {
 	if call.mode != "stopOnFailure" {
 		t.Fatalf("mode = %s, want stopOnFailure", call.mode)
 	}
-	expectedItems := []interface{}{
-		json.RawMessage(`{"foo":"bar"}`),
-		json.RawMessage(`42`),
+	expectedItems := []EnqueueMessage{
+		{Message: json.RawMessage(`{"foo":"bar"}`)},
+		{Message: json.RawMessage(`42`)},
 	}
 	if len(call.items) != len(expectedItems) {
 		t.Fatalf("items length = %d, want %d", len(call.items), len(expectedItems))
 	}
 	for i, item := range call.items {
 		exp := expectedItems[i]
-		rawItem, ok := item.(json.RawMessage)
-		if !ok {
-			t.Fatalf("item %d type = %T, want json.RawMessage", i, item)
-		}
-		rawExp, ok := exp.(json.RawMessage)
-		if !ok {
-			t.Fatalf("expected item %d type = %T, want json.RawMessage", i, exp)
-		}
-		if !bytes.Equal([]byte(rawItem), []byte(rawExp)) {
-			t.Fatalf("item %d = %s, want %s", i, rawItem, rawExp)
+		itemBytes, _ := json.Marshal(item.Item)
+		if !bytes.Equal(itemBytes, exp.Message) {
+			t.Fatalf("item %d = %s, want %s", i, itemBytes, exp.Message)
 		}
 	}
 
 	var resp EnqueueBatchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.Status != "enqueued" {
+		t.Fatalf("response status = %s, want enqueued", resp.Status)
+	}
+	if resp.SuccessCount != mq.enqueueBatchResult {
+		t.Fatalf("success count = %d, want %d", resp.SuccessCount, mq.enqueueBatchResult)
+	}
+
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
@@ -157,7 +159,12 @@ func TestEnqueueBatchHandlerPartialSuccess(t *testing.T) {
 	}
 	server := newTestHTTPServer(mq)
 
-	body := EnqueueBatchRequest{Mode: "partialSuccess", Messages: []json.RawMessage{json.RawMessage(`"good"`), json.RawMessage(`"bad"`)}}
+	enqueueMsgs := []EnqueueMessage{
+		{Message: json.RawMessage(`"good"`)},
+		{Message: json.RawMessage(`"bad"`)},
+	}
+
+	body := EnqueueBatchRequest{Mode: "partialSuccess", Messages: enqueueMsgs}
 	encoded, err := json.Marshal(body)
 	if err != nil {
 		t.Fatalf("failed to marshal request: %v", err)
@@ -233,7 +240,10 @@ func TestEnqueueBatchHandlerQueueError(t *testing.T) {
 	mq := &mockQueue{enqueueBatchError: errors.New("boom")}
 	server := newTestHTTPServer(mq)
 
-	body := EnqueueBatchRequest{Mode: "stopOnFailure", Messages: []json.RawMessage{json.RawMessage(`"msg"`)}}
+	enqueueMsgs := []EnqueueMessage{
+		{Message: json.RawMessage(`"msg"`)},
+	}
+	body := EnqueueBatchRequest{Mode: "stopOnFailure", Messages: enqueueMsgs}
 	encoded, err := json.Marshal(body)
 	if err != nil {
 		t.Fatalf("failed to marshal request: %v", err)

--- a/internal/core/filedb_manager.go
+++ b/internal/core/filedb_manager.go
@@ -127,6 +127,10 @@ func (m *FileDBManager) deleteInterval() error {
 		if deleteAckedErr != nil {
 			return deleteAckedErr
 		}
+		deleteExpiredDupLogErr := m.expireAllDeduplicationLogs(tx)
+		if deleteExpiredDupLogErr != nil {
+			return deleteExpiredDupLogErr
+		}
 		if deleteCnt > 0 || ackedCnt > 0 {
 			if _, err := tx.Exec(`PRAGMA incremental_vacuum(1);`); err != nil {
 				return err

--- a/internal/core/filedb_queue.go
+++ b/internal/core/filedb_queue.go
@@ -97,12 +97,18 @@ func (q *fileDBQueue) DeleteQueue(queue_name string) error {
 	return q.manager.DeleteQueue(queue_name)
 }
 
-func (q *fileDBQueue) Enqueue(queue_name string, item interface{}, delay string) error {
+func (q *fileDBQueue) Enqueue(queue_name string, enqMsg internal.EnqueueMessage) error {
+	item := enqMsg.Item
+	delay := enqMsg.Delay
+	deduplicationID := enqMsg.DeduplicationID
+
 	msg, err := json.Marshal(item)
 	if err != nil {
 		return err
 	}
-	if err := q.manager.WriteMessage(queue_name, msg, delay); err != nil {
+	gid := util.GenerateGlobalID()
+	pid := 0
+	if err := q.manager.WriteMessage(queue_name, msg, gid, pid, delay, deduplicationID); err != nil {
 		q.logger.Error("Error writing message to queue", "error", err)
 		return err
 	}
@@ -110,7 +116,7 @@ func (q *fileDBQueue) Enqueue(queue_name string, item interface{}, delay string)
 	return nil
 }
 
-func (q *fileDBQueue) _enqueueBatchStopOnFailure(queue_name string, items []interface{}, delay string) (int64, error) {
+func (q *fileDBQueue) _enqueueBatchStopOnFailure(queue_name string, items []interface{}, delays []string, deduplicationIDs []string) (int64, error) {
 	var successCount int64 = 0
 	msgs := make([][]byte, 0, len(items))
 	for _, item := range items {
@@ -122,7 +128,7 @@ func (q *fileDBQueue) _enqueueBatchStopOnFailure(queue_name string, items []inte
 		msgs = append(msgs, msg)
 	}
 	pid := 0
-	successCount, err := q.manager.WriteMessagesBatchWithMeta(queue_name, msgs, pid, delay)
+	successCount, err := q.manager.WriteMessagesBatchWithMeta(queue_name, msgs, pid, delays, deduplicationIDs)
 	if err != nil {
 		q.logger.Error("Error writing batch messages to queue", "error", err)
 		return successCount, err
@@ -131,7 +137,7 @@ func (q *fileDBQueue) _enqueueBatchStopOnFailure(queue_name string, items []inte
 	return successCount, nil
 }
 
-func (q *fileDBQueue) _enqueueBatchPartialSuccess(queue_name string, items []interface{}, startIndex int64, delay string) (int64, []internal.FailedMessage, error) {
+func (q *fileDBQueue) _enqueueBatchPartialSuccess(queue_name string, items []interface{}, startIndex int64, delays []string, deduplicationIDs []string) (int64, []internal.FailedMessage, error) {
 	var successCount int64 = 0
 	var failedMessages []internal.FailedMessage
 	msgs := make([][]byte, 0, len(items))
@@ -144,7 +150,7 @@ func (q *fileDBQueue) _enqueueBatchPartialSuccess(queue_name string, items []int
 		msgs = append(msgs, msg)
 	}
 	pid := 0
-	successCount, insertFailedMessages, err := q.manager.WriteMessagesBatchWithMetaAndReturnFailed(queue_name, msgs, pid, delay)
+	successCount, insertFailedMessages, err := q.manager.WriteMessagesBatchWithMetaAndReturnFailed(queue_name, msgs, pid, delays, deduplicationIDs)
 	if err != nil {
 		q.logger.Error("Error writing batch messages to queue", "error", err)
 		// Mark insertFailedMessages as failed
@@ -161,15 +167,33 @@ func (q *fileDBQueue) _enqueueBatchPartialSuccess(queue_name string, items []int
 	return successCount, failedMessages, nil
 }
 
-func (q *fileDBQueue) EnqueueBatch(queue_name, mode, delay string, items []interface{}) (internal.BatchResult, error) {
+func (q *fileDBQueue) EnqueueBatch(queue_name, mode string, enqMsg []internal.EnqueueMessage) (internal.BatchResult, error) {
+	items := make([]interface{}, 0, len(enqMsg))
+	delays := make([]string, 0, len(enqMsg))
+	deduplicationIDs := make([]string, 0, len(enqMsg))
+	for _, em := range enqMsg {
+		items = append(items, em.Item)
+		if em.Delay == "" {
+			em.Delay = "0s"
+		}
+		delays = append(delays, em.Delay)
+		if em.DeduplicationID == "" {
+			deduplicationIDs = append(deduplicationIDs, "")
+		} else {
+			deduplicationIDs = append(deduplicationIDs, em.DeduplicationID)
+		}
+	}
+
 	chunkedMsgs := util.ChunkSlice(items, 100) // Chunk size of 100
+	chunkedDelays := util.ChunkSlice(delays, 100)
+	chunkedDedupIDs := util.ChunkSlice(deduplicationIDs, 100)
 	var totalSuccess int64 = 0
 	var stopError error = nil
 	var failedMessages []internal.FailedMessage
 	switch mode {
 	case "stopOnFailure":
-		for _, chunk := range chunkedMsgs {
-			successCount, err := q._enqueueBatchStopOnFailure(queue_name, chunk, delay)
+		for i, chunk := range chunkedMsgs {
+			successCount, err := q._enqueueBatchStopOnFailure(queue_name, chunk, chunkedDelays[i], chunkedDedupIDs[i])
 			if err != nil {
 				q.logger.Error("Error enqueuing messages", "error", err)
 				return internal.BatchResult{
@@ -194,8 +218,8 @@ func (q *fileDBQueue) EnqueueBatch(queue_name, mode, delay string, items []inter
 		returnFailedMessages := []internal.FailedMessage{}
 		currentIndex := int64(0)
 		// Track the current index across chunks
-		for _, chunk := range chunkedMsgs {
-			successCount, failedMessages, err := q._enqueueBatchPartialSuccess(queue_name, chunk, currentIndex, delay)
+		for i, chunk := range chunkedMsgs {
+			successCount, failedMessages, err := q._enqueueBatchPartialSuccess(queue_name, chunk, currentIndex, chunkedDelays[i], chunkedDedupIDs[i])
 			if err != nil {
 				q.logger.Error("Error enqueuing messages", "error", err)
 				// Mark all messages in this chunk as failed
@@ -228,7 +252,8 @@ func (q *fileDBQueue) Dequeue(queue_name, consumer_group string, consumer_id str
 		ID:      -1,
 		Receipt: "",
 	}
-	msg, err := q.manager.ReadMessage(queue_name, consumer_group, consumer_id, int(q.leaseDuration.Seconds()))
+	partitionID := 0
+	msg, err := q.manager.ReadMessage(queue_name, consumer_group, partitionID, consumer_id, int(q.leaseDuration.Seconds()))
 	if err != nil {
 		switch err {
 		case queue_error.ErrEmpty:
@@ -299,7 +324,8 @@ func (q *fileDBQueue) Status(queue_name string) (internal.QueueStatus, error) {
 
 // bellow new api for http, gRPC
 func (q *fileDBQueue) Peek(queue_name, group_name string) (internal.QueueMessage, error) {
-	msg, err := q.manager.PeekMessage(queue_name, group_name)
+	partitionID := 0
+	msg, err := q.manager.PeekMessage(queue_name, group_name, partitionID)
 	if err != nil {
 		if errors.Is(err, queue_error.ErrEmpty) {
 			return internal.QueueMessage{}, err

--- a/internal/core/filedb_queue_test.go
+++ b/internal/core/filedb_queue_test.go
@@ -52,8 +52,9 @@ func TestFileDBQueueEnqueueBatchSuccess(t *testing.T) {
 
 	mode := "stopOnFailure"
 	delay := "0s"
+	deduplicationID := "dedup-1"
 	batch := []interface{}{"first", map[string]interface{}{"foo": "bar"}}
-	batchResult, err := queue.EnqueueBatch(queueName, mode, delay, batch)
+	batchResult, err := queue.EnqueueBatch(queueName, mode, delay, deduplicationID, batch)
 	if err != nil {
 		t.Fatalf("enqueue batch returned error: %v", err)
 	}
@@ -84,8 +85,9 @@ func TestFileDBQueueEnqueueBatchQueueNotFound(t *testing.T) {
 	queue := newTestQueue(t)
 	mode := "stopOnFailure"
 	delay := "0s"
+	deduplicationID := "dedup-2"
 	batch := []interface{}{"no-queue"}
-	batchResult, err := queue.EnqueueBatch("missing-queue", mode, delay, batch)
+	batchResult, err := queue.EnqueueBatch("missing-queue", mode, delay, deduplicationID, batch)
 	if err == nil {
 		t.Fatal("expected error when enqueueing to missing queue, got nil")
 	}
@@ -105,8 +107,9 @@ func TestFileDBQueueEnqueueBatchStopOnFailureMarshalError(t *testing.T) {
 	invalid := make(chan int)
 	batch := []interface{}{"valid", invalid}
 	delay := "0s"
+	deduplicationID := "dedup-3"
 
-	result, err := queue.EnqueueBatch(queueName, "stopOnFailure", delay, batch)
+	result, err := queue.EnqueueBatch(queueName, "stopOnFailure", delay, deduplicationID, batch)
 	if err == nil {
 		t.Fatal("expected marshal error, got nil")
 	}
@@ -139,8 +142,8 @@ func TestFileDBQueueEnqueueBatchPartialSuccessChunkError(t *testing.T) {
 	}
 	items[100] = make(chan int)
 	delay := "0s"
-
-	result, err := queue.EnqueueBatch(queueName, "partialSuccess", delay, items)
+	deduplicationID := "dedup-4"
+	result, err := queue.EnqueueBatch(queueName, "partialSuccess", delay, deduplicationID, items)
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}

--- a/internal/core/tb_ack.go
+++ b/internal/core/tb_ack.go
@@ -1,0 +1,58 @@
+package core
+
+import "database/sql"
+
+// create acked table
+func (m *FileDBManager) createAckedTable() error {
+	createTableSQL :=
+		`CREATE TABLE IF NOT EXISTS acked (
+		queue_info_id INTEGER NOT NULL,                  -- 큐 정보 ID
+		group_name  TEXT NOT NULL,                       -- 컨슈머 그룹
+		partition_id INTEGER NOT NULL DEFAULT 0,		 -- 파티션 ID
+		global_id TEXT NOT NULL DEFAULT '',			 -- 글로벌 ID (복제시 사용, UUID 사용)
+		acked_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (queue_info_id, group_name, partition_id, global_id),                   -- 큐별, 그룹별 메시지 1개만 점유 가능
+		FOREIGN KEY (queue_info_id) REFERENCES queue_info(id) ON DELETE CASCADE
+	);`
+	_, err := m.db.Exec(createTableSQL)
+	if err != nil {
+		return err
+	}
+	createIndex := `CREATE INDEX IF NOT EXISTS idx_acked_lookup
+  					ON acked(queue_info_id, global_id, partition_id, group_name);`
+	_, err = m.db.Exec(createIndex)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// insertAcked acked 테이블에 삽입
+func (m *FileDBManager) insertAcked(tx *sql.Tx, queueInfoID int64, group string, partitionID int, globalID string) error {
+	// acked에 삽입
+	if _, err := tx.Exec(`
+			INSERT OR IGNORE INTO acked 
+			(queue_info_id, group_name, partition_id, global_id) 
+			VALUES (?, ?, ?, ?)`, queueInfoID, group, partitionID, globalID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// deleteAckedMsg acked 테이블에서 오래된 항목 삭제
+func (m *FileDBManager) deleteAckedMsg(tx *sql.Tx) (int64, error) {
+	res, err := tx.Exec(`
+			DELETE FROM acked
+			WHERE (queue_info_id, acked_at) IN (
+				SELECT qi.id, a.acked_at
+				FROM acked a
+					JOIN queue_info qi 
+						ON qi.id = a.queue_info_id
+				WHERE a.acked_at <= DATETIME('now', printf('-%d seconds', qi.retention_s))
+		);`)
+	if err != nil {
+		return 0, err
+	}
+	resAffected, err := res.RowsAffected()
+	return resAffected, err
+}

--- a/internal/core/tb_deduplication_log.go
+++ b/internal/core/tb_deduplication_log.go
@@ -52,6 +52,16 @@ func (m *FileDBManager) checkDuplicationID(tx *sql.Tx, queueInfoID int64, dedupI
 	return res, nil
 }
 
+// 전체 deduplication_log 중 만료된 로그 삭제
+func (m *FileDBManager) expireAllDeduplicationLogs(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+		DELETE FROM deduplication_log
+		WHERE
+		expires_at <= CURRENT_TIMESTAMP;`,
+	)
+	return err
+}
+
 // expireDeduplicationLogs 만료된 deduplication_log 삭제
 func (m *FileDBManager) expireDeduplicationLogs(tx *sql.Tx, queue_info_id int64, dedupID string) error {
 	_, err := tx.Exec(`

--- a/internal/core/tb_deduplication_log.go
+++ b/internal/core/tb_deduplication_log.go
@@ -12,12 +12,15 @@ func (m *FileDBManager) createDeduplicationLogTable() error {
 	createTableSQL := `
 		-- 중복 로그
 		CREATE TABLE IF NOT EXISTS deduplication_log (
+		id INTEGER,
 		queue_info_id INTEGER NOT NULL,
 		deduplication_id TEXT NOT NULL,
 		expires_at TIMESTAMP NOT NULL,
 		queue_row_id INTEGER,                      -- 최초 삽입된 queue.id를 기록(선택) 
 		insert_ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-		PRIMARY KEY (queue_info_id, deduplication_id)  -- UNIQUE 대용 (SQLite는 PK=UNIQUE)
+		PRIMARY KEY (id),
+		UNIQUE(queue_info_id, deduplication_id),
+		FOREIGN KEY (queue_info_id) REFERENCES queue_info(id) ON DELETE CASCADE
 		);`
 	_, err := m.db.Exec(createTableSQL)
 

--- a/internal/core/tb_deduplication_log.go
+++ b/internal/core/tb_deduplication_log.go
@@ -1,0 +1,106 @@
+package core
+
+import (
+	"database/sql"
+	"fmt"
+	"go-msg-queue-mini/internal/queue_error"
+	"time"
+)
+
+// create deduplication_log table
+func (m *FileDBManager) createDeduplicationLogTable() error {
+	createTableSQL := `
+		-- 중복 로그
+		CREATE TABLE IF NOT EXISTS deduplication_log (
+		queue_info_id INTEGER NOT NULL,
+		deduplication_id TEXT NOT NULL,
+		expires_at TIMESTAMP NOT NULL,
+		queue_row_id INTEGER,                      -- 최초 삽입된 queue.id를 기록(선택) 
+		insert_ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		PRIMARY KEY (queue_info_id, deduplication_id)  -- UNIQUE 대용 (SQLite는 PK=UNIQUE)
+		);`
+	_, err := m.db.Exec(createTableSQL)
+
+	// -- (선택) 만료/조회 최적화용 보조 인덱스
+	if err != nil {
+		return err
+	}
+	createIndex := `CREATE INDEX IF NOT EXISTS idx_dedup_expires ON deduplication_log (expires_at);`
+	_, err = m.db.Exec(createIndex)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *FileDBManager) checkDuplicationID(tx *sql.Tx, queueInfoID int64, dedupID string) (int64, error) {
+	// delete 만료된 로그
+	if err := m.expireDeduplicationLogs(tx, queueInfoID, dedupID); err != nil {
+		return 0, fmt.Errorf("error expiring deduplication logs: %w", err)
+	}
+	// 중복 검사 및 삽입 시도
+	res, err := m.insertDeduplicationLogs(tx, queueInfoID, dedupID, 24*time.Hour)
+	if err != nil {
+		return 0, fmt.Errorf("error inserting deduplication log: %w", err)
+	}
+	return res, nil
+}
+
+// expireDeduplicationLogs 만료된 deduplication_log 삭제
+func (m *FileDBManager) expireDeduplicationLogs(tx *sql.Tx, queue_info_id int64, dedupID string) error {
+	_, err := tx.Exec(`
+		DELETE FROM deduplication_log
+		WHERE
+		queue_info_id = ? AND
+		deduplication_id = ? AND
+		expires_at <= CURRENT_TIMESTAMP;`,
+		queue_info_id, dedupID)
+	return err
+}
+
+// dedup_log 삽입
+func (m *FileDBManager) insertDeduplicationLogs(tx *sql.Tx, queue_info_id int64, dedupID string, expiresIn time.Duration) (int64, error) {
+	insertQuery :=
+		`INSERT INTO deduplication_log (queue_info_id, deduplication_id, expires_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(queue_info_id, deduplication_id) DO NOTHING;`
+	res, err := tx.Exec(insertQuery, queue_info_id, dedupID, time.Now().Add(expiresIn))
+	if err != nil {
+		return 0, fmt.Errorf("error inserting deduplication log: %w", err)
+	}
+	resAffected, err := res.RowsAffected()
+	if err != nil || resAffected <= 0 {
+		return 0, queue_error.ErrDuplicate
+	}
+	// return deduplication log id
+	resID, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("error getting last insert id: %w", err)
+	}
+	return resID, nil
+}
+
+// updateDeduplicationLogWithQueueRowID deduplication_log의 queue_row_id 업데이트
+func (m *FileDBManager) updateDeduplicationLogWithQueueRowID(tx *sql.Tx, log_id int64, queue_row_id int64) error {
+	updateQuery := `
+		UPDATE deduplication_log
+		SET queue_row_id = ?
+		WHERE id = ?;`
+	_, err := tx.Exec(updateQuery, queue_row_id, log_id)
+	if err != nil {
+		return fmt.Errorf("error updating deduplication log with queue_row_id: %w", err)
+	}
+	return nil
+}
+
+// deleteDeduplicationLogs deduplication_log 삭제
+func (m *FileDBManager) deleteDeduplicationLogs(tx *sql.Tx, log_id int64) error {
+	deleteQuery := `
+		DELETE FROM deduplication_log
+		WHERE id = ?;`
+	_, err := tx.Exec(deleteQuery, log_id)
+	if err != nil {
+		return fmt.Errorf("error deleting deduplication log: %w", err)
+	}
+	return nil
+}

--- a/internal/core/tb_dlq.go
+++ b/internal/core/tb_dlq.go
@@ -1,0 +1,35 @@
+package core
+
+import "database/sql"
+
+// create dlq table
+func (m *FileDBManager) createDLQTable() error {
+	createTableSQL :=
+		`CREATE TABLE IF NOT EXISTS dlq (
+		id INTEGER PRIMARY KEY,                          -- rowid 기반 PK
+		queue_info_id INTEGER NOT NULL,                  -- 큐 정보 ID
+    	q_id INTEGER NOT NULL,                           -- 원본 queue.id
+		partition_id INTEGER NOT NULL DEFAULT 0,		 -- 파티션 ID
+		global_id TEXT NOT NULL DEFAULT '',			 -- 글로벌 ID (복제시 사용, UUID 사용)
+    	msg BLOB,                                        -- 메시지 복사본
+    	failed_group TEXT,                               -- 실패한 컨슈머 그룹
+    	reason TEXT,                                     -- 실패 사유
+    	insert_ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, -- 그룹별 메시지 1개만 점유 가능
+		FOREIGN KEY (queue_info_id) REFERENCES queue_info(id) ON DELETE CASCADE,
+		FOREIGN KEY (q_id) REFERENCES queue(id) ON DELETE CASCADE
+	);`
+	_, err := m.db.Exec(createTableSQL)
+	return err
+}
+
+// insert dlq
+func (m *FileDBManager) insertDLQ(tx *sql.Tx, queueInfoID int64, partitionID int, globalID string, msg []byte, group string, reason string) error {
+	if _, err := tx.Exec(`
+			INSERT INTO dlq(q_id, queue_info_id, global_id, partition_id, msg, failed_group, reason)
+			SELECT q.id, q.queue_info_id, q.global_id, q.partition_id, q.msg, ?, ?
+			FROM queue q WHERE q.queue_info_id = ? AND q.global_id = ? AND q.partition_id = ?
+			`, group, reason, queueInfoID, globalID, partitionID); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/core/tb_inflight.go
+++ b/internal/core/tb_inflight.go
@@ -1,0 +1,179 @@
+package core
+
+import (
+	"database/sql"
+	queue_error "go-msg-queue-mini/internal/queue_error"
+)
+
+// create inflight table
+func (m *FileDBManager) createInflightTable() error {
+	createTableSQL :=
+		`CREATE TABLE IF NOT EXISTS inflight (
+		q_id           INTEGER NOT NULL,
+		queue_info_id  INTEGER NOT NULL,                  -- 큐 정보 ID
+		group_name     TEXT    NOT NULL,
+		consumer_id    TEXT    NOT NULL, -- 추가!
+		lease_until    TIMESTAMP NOT NULL,
+		delivery_count INTEGER NOT NULL DEFAULT 1,
+		receipt        TEXT,
+		last_error     TEXT,
+		claimed_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		partition_id INTEGER NOT NULL DEFAULT 0,		 -- 파티션 ID
+		global_id TEXT NOT NULL DEFAULT '',			 -- 글로벌 ID (복제시 사용, UUID 사용)
+		PRIMARY KEY (queue_info_id, group_name, partition_id, q_id),
+		FOREIGN KEY (q_id) REFERENCES queue(id) ON DELETE CASCADE,
+		FOREIGN KEY (queue_info_id) REFERENCES queue_info(id) ON DELETE CASCADE
+	);`
+	_, err := m.db.Exec(createTableSQL)
+	if err != nil {
+		return err
+	}
+	createIndex := `CREATE INDEX IF NOT EXISTS idx_inflight_lease 
+					ON inflight(queue_info_id, group_name, partition_id, lease_until);`
+	_, err = m.db.Exec(createIndex)
+	if err != nil {
+		return err
+	}
+	createIndex2 := `CREATE UNIQUE INDEX IF NOT EXISTS idx_inflight_receipt 
+					ON inflight(receipt);`
+	_, err = m.db.Exec(createIndex2)
+	if err != nil {
+		return err
+	}
+	// 글로벌 ID + 파티션 ID + 큐 정보 ID + receipt으로도 조회 가능해야 함
+	_, err = m.db.Exec(`
+	CREATE INDEX IF NOT EXISTS idx_inflight_global_receipt
+	ON inflight(queue_info_id, global_id, partition_id, receipt);
+	`)
+	if err != nil {
+		return err
+	}
+	// 글로벌 ID + 파티션 ID + 큐 정보 ID + 그룹명으로도 조회 가능해야 함
+	_, err = m.db.Exec(`
+	CREATE INDEX IF NOT EXISTS idx_inflight_global_group
+	ON inflight(queue_info_id, global_id, partition_id, group_name);
+	`)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// 선점 시도 (UPSERT). leaseSec는 정수(초)
+func (m *FileDBManager) upsertInflight(
+	tx *sql.Tx, queueInfoID int64, group string, consumerID string, leaseSec int, candID int64, partitionID int, globalID string) error {
+	// 2) 선점 시도 (UPSERT). leaseSec는 정수(초)
+	res, err := tx.Exec(`
+			INSERT INTO 
+				inflight(
+					q_id, queue_info_id, group_name, consumer_id, lease_until, 
+					delivery_count, claimed_at, receipt, partition_id, 
+					global_id)
+			SELECT ?, ?, ?, ?, DATETIME('now', ? || ' seconds'),
+				COALESCE(
+				(SELECT delivery_count FROM inflight 
+				WHERE queue_info_id = ? AND group_name=? AND partition_id=? AND q_id=?),0)+1,
+				CURRENT_TIMESTAMP,
+				lower(hex(randomblob(16))) AS receipt,
+				?, ?
+			WHERE NOT EXISTS (
+				SELECT 1 FROM inflight
+				WHERE queue_info_id = ? AND group_name=? AND partition_id=? AND q_id=? AND lease_until > CURRENT_TIMESTAMP
+			)
+			ON CONFLICT(queue_info_id, group_name, partition_id, q_id) DO UPDATE SET
+			consumer_id    = excluded.consumer_id,
+			lease_until    = excluded.lease_until,
+			delivery_count = inflight.delivery_count + 1,
+			claimed_at     = CURRENT_TIMESTAMP,
+			receipt        = excluded.receipt
+			WHERE inflight.lease_until <= CURRENT_TIMESTAMP
+		`, candID, queueInfoID, group, consumerID, leaseSec,
+		queueInfoID, group, partitionID, candID,
+		partitionID, globalID,
+		queueInfoID, group, partitionID, candID)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if n == 0 || err != nil {
+		// 경합으로 못 집었음 → 상위 레벨에서 재호출(또는 이 함수 내부에서 짧은 루프)
+		return queue_error.ErrContended
+	}
+	return nil
+}
+
+// delete inflight record (ack)
+func (m *FileDBManager) deleteInflight(tx *sql.Tx, queueInfoID int64, globalID string, partitionID int, group string, receipt string) (err error) {
+	if _, err = tx.Exec(`
+			DELETE FROM inflight WHERE 
+				queue_info_id = ? AND 
+				global_id = ? AND 
+				partition_id = ? AND 
+				group_name = ? AND 
+				receipt = ?`, queueInfoID, globalID, partitionID, group, receipt); err != nil {
+		return err
+	}
+	return nil
+}
+
+// get delivery count
+func (m *FileDBManager) getInflightDeliveryCount(
+	tx *sql.Tx, queueInfoID int64, globalID string, partitionID int, receipt string) (deliveryCount int, err error) {
+	var retryCount int
+	if err = tx.QueryRow(
+		`SELECT delivery_count
+		FROM inflight
+		WHERE queue_info_id = ? AND global_id = ? AND partition_id = ? AND receipt = ?`,
+		queueInfoID, globalID, partitionID, receipt).Scan(&retryCount); err != nil {
+		return -1, err
+	}
+	return retryCount, nil
+}
+
+// update lease time, delivery count, last error (nack)
+func (m *FileDBManager) updateInflightNack(
+	tx *sql.Tx, queueInfoID int64, globalID string, partitionID int,
+	receipt string, backoffSec int, lastError string) (err error) {
+	res, err := tx.Exec(`
+        UPDATE inflight
+        SET lease_until    = DATETIME('now', ? || ' seconds'),
+            delivery_count = delivery_count + 1,
+            last_error     = ?
+        WHERE queue_info_id = ? AND global_id = ? AND partition_id = ? AND receipt = ?
+    	`, backoffSec,
+		lastError,
+		queueInfoID, globalID, partitionID, receipt)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return queue_error.ErrContended
+	}
+	return nil
+}
+
+// renew lease time
+func (m *FileDBManager) renewInflightLease(
+	tx *sql.Tx, queueInfoID int64, group, globalID string,
+	receipt string, extendSec int) (err error) {
+	res, err := tx.Exec(`
+			UPDATE inflight
+			SET lease_until = DATETIME('now', '+' || ? || ' seconds')
+			WHERE queue_info_id = ? AND group_name = ? AND global_id = ? AND receipt = ?
+			AND lease_until > CURRENT_TIMESTAMP
+		`, extendSec,
+		queueInfoID, group, globalID, receipt)
+	if err != nil {
+		return err
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return queue_error.ErrLeaseExpired
+	}
+	return nil
+}

--- a/internal/core/tb_queue.go
+++ b/internal/core/tb_queue.go
@@ -1,0 +1,392 @@
+package core
+
+import (
+	"database/sql"
+	"fmt"
+	"go-msg-queue-mini/internal"
+	queue_error "go-msg-queue-mini/internal/queue_error"
+	"go-msg-queue-mini/util"
+)
+
+// create queue msg table
+func (m *FileDBManager) createQueueTable() error {
+	createTableSQL :=
+		`CREATE TABLE IF NOT EXISTS queue (
+		id INTEGER PRIMARY KEY,                          -- rowid 기반 고유 PK
+		queue_info_id INTEGER NOT NULL,                  -- 큐 정보 ID
+    	msg BLOB NOT NULL,                               -- 메시지 본문
+		partition_id INTEGER NOT NULL DEFAULT 0,		 -- 파티션 ID
+		global_id TEXT NOT NULL DEFAULT '',			 -- 글로벌 ID (복제시 사용, UUID 사용)
+    	insert_ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		FOREIGN KEY (queue_info_id) REFERENCES queue_info(id) ON DELETE CASCADE
+	);`
+	_, err := m.db.Exec(createTableSQL)
+	if err != nil {
+		return err
+	}
+
+	// if not exists visible_at then add column (초기값은 insert_ts)
+	rows, err := m.db.Query(`PRAGMA table_info(queue);`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var check_visible_at bool
+	for rows.Next() {
+		var cid int
+		var name string
+		var ctype string
+		var notnull int
+		var dflt_value *string
+		var pk int
+
+		err = rows.Scan(&cid, &name, &ctype, &notnull, &dflt_value, &pk)
+		if err != nil {
+			return err
+		}
+
+		if name == "visible_at" {
+			check_visible_at = true
+			break
+		}
+	}
+	if err = rows.Err(); err != nil {
+		return err
+	}
+
+	if !check_visible_at {
+		_, err = m.db.Exec(`ALTER TABLE queue ADD COLUMN visible_at TIMESTAMP;`)
+		if err != nil {
+			return err
+		}
+
+		// 기존 데이터들의 visible_at 값을 insert_ts 값으로 초기화
+		_, err = m.db.Exec(`UPDATE queue SET visible_at = insert_ts WHERE visible_at IS NULL;`)
+		if err != nil {
+			return err
+		}
+	}
+
+	createIndex := `CREATE UNIQUE INDEX IF NOT EXISTS uq_queue_global ON queue(queue_info_id, global_id);`
+	_, err = m.db.Exec(createIndex)
+	if err != nil {
+		return err
+	}
+	createIndex2 := `CREATE INDEX IF NOT EXISTS idx_queue_partition ON queue(queue_info_id, partition_id, visible_at, id);`
+	_, err = m.db.Exec(createIndex2)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// insert message to queue
+func (m *FileDBManager) insertMessage(
+	tx *sql.Tx, queueInfoID int64, msg []byte, globalID string, partitionID int,
+	mod string) (int64, error) {
+	// 메시지 삽입
+	res, err := tx.Exec(`
+		INSERT INTO queue 
+		(queue_info_id, msg, global_id, partition_id, visible_at) 
+		VALUES (?, ?, ?, ?, DATETIME('now', ?));`,
+		queueInfoID, msg, globalID, partitionID, mod)
+	if err != nil {
+		return -1, err
+	}
+	queueRowId, err := res.LastInsertId()
+	if err != nil {
+		return -1, err
+	}
+	return queueRowId, nil
+}
+
+// insert messagebatch to queue (stopOnFailure mode)
+func (m *FileDBManager) insertMessageBatchStopOnFailure(
+	tx *sql.Tx, queueInfoID int64, msgs [][]byte, partitionID int,
+	delays []string, deduplicationIDs []string) (int64, error) {
+	var txCnt int64 = 0
+
+	stmt, err := tx.Prepare(`
+			INSERT INTO queue 
+			(queue_info_id, msg, global_id, partition_id, visible_at) 
+			VALUES (?, ?, ?, ?, DATETIME('now', ?))`)
+	if err != nil {
+		return txCnt, err
+	}
+	defer stmt.Close()
+
+	for i, msg := range msgs {
+		var delay string = "+0 seconds"
+		if i < len(delays) {
+			delay = delays[i]
+		}
+		mod, err := util.DelayToSeconds(delay) // "+0 seconds"
+		if err != nil {
+			return txCnt, err
+		}
+		var dedupID string = ""
+		if i < len(deduplicationIDs) {
+			dedupID = deduplicationIDs[i]
+		}
+		// deduplicationID가 있으면 중복 검사
+		if dedupID != "" {
+			logId, err := m.checkDuplicationID(tx, queueInfoID, dedupID)
+			if err != nil {
+				return txCnt, fmt.Errorf("error checking duplication ID: %w", err)
+			}
+			globalID := util.GenerateGlobalID()
+			_, insertErr := stmt.Exec(queueInfoID, msg, globalID, partitionID, mod)
+			if insertErr != nil {
+				return txCnt, insertErr
+			}
+			// log_id, queue_row_id 업데이트
+			if err := m.updateDeduplicationLogWithQueueRowID(tx, logId, txCnt+1); err != nil {
+				m.deleteDeduplicationLogs(tx, logId) // 삽입 실패시 deduplication_log 삭제
+				return txCnt, fmt.Errorf("error updating deduplication log with queue row ID: %w", err)
+			}
+		} else {
+			globalID := util.GenerateGlobalID()
+			_, insertErr := stmt.Exec(queueInfoID, msg, globalID, partitionID, mod)
+			if insertErr != nil {
+				return txCnt, insertErr
+			}
+		}
+		txCnt++
+	}
+	return txCnt, nil
+}
+
+// insert messagebatch to queue (partialSuccess mode)
+func (m *FileDBManager) insertMessageBatchReturnFailed(
+	tx *sql.Tx, queueInfoID int64, msgs [][]byte, partitionID int,
+	delays []string, deduplicationIDs []string, startIndex int64) (successCnt int64, failedMessages []internal.FailedMessage, err error) {
+	stmt, err := tx.Prepare(`
+			INSERT INTO queue 
+			(queue_info_id, msg, global_id, partition_id, visible_at) 
+			VALUES (?, ?, ?, ?, DATETIME('now', ?))
+			ON CONFLICT(queue_info_id, global_id) DO NOTHING
+			`)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer stmt.Close()
+
+	var txCnt int64 = 0
+	for i, msg := range msgs {
+		globalID := util.GenerateGlobalID()
+		var delay string = "+0 seconds"
+		if i < len(delays) {
+			delay = delays[i]
+		}
+		mod, err := util.DelayToSeconds(delay) // "+0 seconds"
+		if err != nil {
+			return txCnt, nil, err
+		}
+		var dedupID string = ""
+		if i < len(deduplicationIDs) {
+			dedupID = deduplicationIDs[i]
+		}
+		// deduplicationID가 있으면 중복 검사
+		if dedupID != "" {
+			logId, err := m.checkDuplicationID(tx, queueInfoID, dedupID)
+			if err != nil {
+				failedMessages = append(failedMessages, internal.FailedMessage{
+					Index:   int64(i) + startIndex,
+					Reason:  fmt.Sprintf("error checking duplication ID: %v", err),
+					Message: msg,
+				})
+				continue
+			}
+			queue_row_id, failedMessage, insertErr := m.partialSuccess(tx, stmt, queueInfoID, msg, globalID, partitionID, mod, startIndex+int64(i))
+			if insertErr != nil {
+				failedMessages = append(failedMessages, failedMessage)
+				m.deleteDeduplicationLogs(tx, logId) // 삽입 실패시 로그 삭제
+				continue
+			}
+
+			// log_id, queue_row_id 업데이트
+			if err := m.updateDeduplicationLogWithQueueRowID(tx, logId, queue_row_id); err != nil {
+				failedMessages = append(failedMessages, internal.FailedMessage{
+					Index:   int64(i) + startIndex,
+					Reason:  fmt.Sprintf("error updating deduplication log with queue row ID: %v", err),
+					Message: msg,
+				})
+				m.deleteDeduplicationLogs(tx, logId) // 삽입 실패시 로그 삭제
+				continue
+			}
+			txCnt++
+		} else {
+			// msg 단위 savepoint
+			_, failedMessage, insertErr := m.partialSuccess(tx, stmt, queueInfoID, msg, globalID, partitionID, mod, startIndex+int64(i))
+			if insertErr != nil {
+				failedMessages = append(failedMessages, failedMessage)
+				continue
+			}
+			txCnt++
+		}
+
+	}
+	if txCnt > 0 {
+		return txCnt, failedMessages, nil
+	} else {
+		return 0, failedMessages, fmt.Errorf("all messages failed to insert")
+	}
+}
+
+// msg 단위로 삽입 시도, 실패시 롤백 후 실패 사유 리턴
+func (m *FileDBManager) partialSuccess(tx *sql.Tx, stmt *sql.Stmt,
+	queueInfoID int64, msg []byte, globalID string, partitionID int, mod string, order int64) (queue_row_id int64, failedMessage internal.FailedMessage, err error) {
+	// msg 단위 savepoint
+	sp := fmt.Sprintf("sp_%d", order)
+	if _, err := tx.Exec(fmt.Sprintf("SAVEPOINT %s;", sp)); err != nil {
+
+	}
+	res, insertErr := stmt.Exec(queueInfoID, msg, globalID, partitionID, mod)
+	if insertErr != nil {
+		_, _ = tx.Exec(fmt.Sprintf("ROLLBACK TO %s;", sp))
+		_, _ = tx.Exec(fmt.Sprintf("RELEASE %s;", sp))
+		failedMessage = internal.FailedMessage{
+			Index:   int64(order),
+			Reason:  insertErr.Error(),
+			Message: msg,
+		}
+		return -1, failedMessage, insertErr
+	}
+
+	if ra, _ := res.RowsAffected(); ra == 0 {
+		// 중복으로 삽입 안된 경우
+		_, _ = tx.Exec(fmt.Sprintf("ROLLBACK TO %s;", sp))
+		_, _ = tx.Exec(fmt.Sprintf("RELEASE %s;", sp))
+		failedMessage = internal.FailedMessage{
+			Index:   int64(order),
+			Reason:  "duplicate message",
+			Message: msg,
+		}
+		return -1, failedMessage, fmt.Errorf("duplicate message")
+	}
+	queue_row_id, err = res.LastInsertId()
+	if err != nil {
+		_, _ = tx.Exec(fmt.Sprintf("ROLLBACK TO %s;", sp))
+		_, _ = tx.Exec(fmt.Sprintf("RELEASE %s;", sp))
+		failedMessage = internal.FailedMessage{
+			Index:   int64(order),
+			Reason:  fmt.Sprintf("error getting last insert ID: %v", err),
+			Message: msg,
+		}
+		return -1, failedMessage, fmt.Errorf("error getting last insert ID: %v", err)
+	}
+
+	if _, err := tx.Exec(fmt.Sprintf("RELEASE %s;", sp)); err != nil {
+		_, _ = tx.Exec(fmt.Sprintf("ROLLBACK TO %s;", sp))
+	}
+	return queue_row_id, internal.FailedMessage{}, nil
+}
+
+// 후보 메시지 조회
+func (m *FileDBManager) getCandidateQueueMsg(tx *sql.Tx, queueInfoID int64, group string, partitionID int) (candidateMsg queueMsg, err error) {
+	// 1) 후보 조회
+	err = tx.QueryRow(`
+			SELECT q.id, q.msg, q.insert_ts, "" as receipt, q.global_id, q.partition_id
+			FROM queue q
+			LEFT JOIN acked a
+				ON a.queue_info_id = q.queue_info_id 
+				AND a.global_id = q.global_id 
+				AND a.group_name = ? 
+				AND a.partition_id = ?
+			LEFT JOIN inflight i 
+				ON i.queue_info_id = q.queue_info_id 
+				AND i.q_id = q.id 
+				AND i.group_name = ? 
+				AND i.partition_id = ?
+			JOIN queue_info qi
+				ON qi.id = q.queue_info_id
+			WHERE
+			q.queue_info_id = ? 
+			AND q.visible_at <= CURRENT_TIMESTAMP
+			AND a.global_id IS NULL
+			AND (i.q_id IS NULL OR i.lease_until <= CURRENT_TIMESTAMP)
+			AND q.partition_id = ?
+			ORDER BY q.id ASC
+			LIMIT 1
+		`, group, partitionID,
+		group, partitionID,
+		queueInfoID, partitionID).Scan(
+		&candidateMsg.ID, &candidateMsg.Msg,
+		&candidateMsg.InsertTS, &candidateMsg.Receipt,
+		&candidateMsg.GlobalID, &candidateMsg.PartitionID)
+	if err == sql.ErrNoRows {
+		return queueMsg{}, queue_error.ErrNoMessage
+	}
+	if err != nil {
+		return queueMsg{}, err
+	}
+	return candidateMsg, nil
+}
+
+// 내가 점유한 메시지 반환 (consumer_id로 한정)
+func (m *FileDBManager) getLeaseMsg(
+	tx *sql.Tx, queueInfoID int64, group string, consumerID string, partitionID int) (queueMsg, error) {
+	var msg queueMsg
+	err := tx.QueryRow(`
+			SELECT 
+			q.id, q.msg, q.insert_ts, i.receipt, q.global_id, q.partition_id
+			FROM queue q
+			JOIN inflight i ON 
+				i.q_id = q.id AND
+				i.queue_info_id = q.queue_info_id
+			JOIN queue_info qi ON
+				qi.id = q.queue_info_id
+			WHERE 
+				i.queue_info_id = ? 
+				AND i.group_name = ? 
+				AND i.consumer_id = ? 
+				AND i.partition_id = ?
+			ORDER BY i.claimed_at DESC
+			LIMIT 1
+		`, queueInfoID, group, consumerID, partitionID).Scan(
+		&msg.ID, &msg.Msg, &msg.InsertTS, &msg.Receipt, &msg.GlobalID, &msg.PartitionID)
+	if err != nil {
+		return queueMsg{}, err
+	}
+	return msg, nil
+}
+
+// exist check by msg_id
+func (m *FileDBManager) existsMsgID(tx *sql.Tx, msgID int64) (global_id string, partition_id int, err error) {
+	err = tx.QueryRow(`SELECT global_id, partition_id FROM queue WHERE id = ?`, msgID).Scan(&global_id, &partition_id)
+	if err == sql.ErrNoRows {
+		return "", 0, queue_error.ErrMessageNotFound
+	}
+	if err != nil {
+		return "", 0, err
+	}
+	return global_id, partition_id, nil
+}
+
+// delete queue message
+func (m *FileDBManager) deleteQueueMsg(tx *sql.Tx) (int64, error) {
+	res, err := tx.Exec(`
+			DELETE FROM queue
+			WHERE id IN (
+				SELECT q.id
+				FROM queue q
+					JOIN queue_info qi 
+						ON qi.id = q.queue_info_id
+					LEFT JOIN inflight i
+						ON i.queue_info_id = q.queue_info_id
+						AND i.q_id         = q.id
+				WHERE 
+					i.q_id IS NULL
+					AND q.insert_ts <= DATETIME('now', printf('-%d seconds', qi.retention_s))
+			);
+		`)
+	if err != nil {
+		return 0, err
+	}
+	resAffected, err := res.RowsAffected()
+	if err != nil || resAffected <= 0 {
+		return 0, err
+	}
+	return resAffected, nil
+}

--- a/internal/core/tb_queue_info.go
+++ b/internal/core/tb_queue_info.go
@@ -1,0 +1,102 @@
+package core
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// create queue info table
+func (m *FileDBManager) createQueueInfoTable() error {
+	createTableSQL :=
+		`CREATE TABLE IF NOT EXISTS queue_info (
+		id INTEGER PRIMARY KEY,                          -- rowid 기반 고유 PK
+		name TEXT NOT NULL UNIQUE,                        -- 큐 이름
+		retention_s  INTEGER NOT NULL DEFAULT 86400,  -- 메시지 보관기간(초) 정책
+		max_delivery INTEGER NOT NULL DEFAULT 10,     -- 기본 최대 재시도
+		backoff_base INTEGER NOT NULL DEFAULT 1,      -- 기본 백오프 초
+		partition_n  INTEGER NOT NULL DEFAULT 1,      -- 파티션 개수(미래 대비)
+		created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);`
+	_, err := m.db.Exec(createTableSQL)
+	return err
+}
+
+func (m *FileDBManager) getQueueInfoID(name string) (int64, error) {
+	var id int64
+	if v, ok := m.queueNameMap.Load(name); ok {
+		return v.(int64), nil
+	}
+	err := m.db.QueryRow(`SELECT id FROM queue_info WHERE name = ?`, name).Scan(&id)
+	if err == sql.ErrNoRows {
+		return -1, fmt.Errorf("queue not found: %s", name)
+	}
+	if err != nil {
+		return -1, err
+	}
+	m.queueNameMap.Store(name, id)
+	return id, nil
+}
+
+func (m *FileDBManager) ListQueues() ([]string, error) {
+	rows, err := m.db.Query(`SELECT name FROM queue_info ORDER BY name ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var queues []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		queues = append(queues, name)
+	}
+	return queues, nil
+}
+
+func (m *FileDBManager) CreateQueue(name string) error {
+	defaultRetention := OneDayInSeconds
+	defaultMaxDelivery := 10
+	defaultBackoffBase := 1
+	defaultPartitionN := 1
+	return m.createQueue(name, defaultRetention, defaultMaxDelivery, defaultBackoffBase, defaultPartitionN)
+}
+
+func (m *FileDBManager) createQueue(name string, retentionSec, maxDelivery, backoffBase, partitionN int) error {
+
+	if name == "" {
+		return fmt.Errorf("queue name is required")
+	}
+	// 중복 검사
+	if _, err := m.getQueueInfoID(name); err == nil {
+		return nil // 이미 존재하면 그냥 통과
+	}
+
+	row, err := m.db.Exec(`
+		INSERT INTO queue_info (name, retention_s, max_delivery, backoff_base, partition_n)
+		VALUES (?, ?, ?, ?, ?)`, name, retentionSec, maxDelivery, backoffBase, partitionN)
+	if err != nil {
+		return err
+	}
+	rowID, err := row.LastInsertId()
+	if err != nil {
+		return err
+	}
+	m.queueNameMap.Store(name, rowID)
+	return nil
+}
+
+func (m *FileDBManager) DeleteQueue(name string) error {
+	// 존재하는지 확인
+	if _, err := m.getQueueInfoID(name); err != nil {
+		return err
+	}
+
+	_, err := m.db.Exec(`DELETE FROM queue_info WHERE name = ?`, name)
+	if err != nil {
+		return err
+	}
+	m.queueNameMap.Delete(name)
+	return nil
+}

--- a/internal/queue.go
+++ b/internal/queue.go
@@ -27,12 +27,18 @@ type FailedMessage struct {
 	Reason  string
 }
 
+type EnqueueMessage struct {
+	Item            interface{}
+	Delay           string
+	DeduplicationID string
+}
+
 // add queue_name
 type Queue interface {
 	CreateQueue(queue_name string) error
 	DeleteQueue(queue_name string) error
-	Enqueue(queue_name string, item interface{}, delay string) error
-	EnqueueBatch(queue_name, mode, delay string, items []interface{}) (BatchResult, error)
+	Enqueue(queue_name string, msg EnqueueMessage) error
+	EnqueueBatch(queue_name, mode string, msgs []EnqueueMessage) (BatchResult, error)
 	Dequeue(queue_name string, group_name string, consumer_id string) (QueueMessage, error)
 	Ack(queue_name string, group_name string, messageID int64, receipt string) error
 	Nack(queue_name string, group_name string, messageID int64, receipt string) error

--- a/internal/queue_error/errors.go
+++ b/internal/queue_error/errors.go
@@ -3,7 +3,10 @@ package queue_error
 import "errors"
 
 var (
-	ErrEmpty        = errors.New("queue empty")
-	ErrContended    = errors.New("contention: message not claimed")
-	ErrLeaseExpired = errors.New("lease expired")
+	ErrEmpty           = errors.New("queue empty")
+	ErrContended       = errors.New("contention: message not claimed")
+	ErrNoMessage       = errors.New("no message available")
+	ErrLeaseExpired    = errors.New("lease expired")
+	ErrDuplicate       = errors.New("duplicate message")
+	ErrMessageNotFound = errors.New("message not found")
 )

--- a/internal/runner/producer.go
+++ b/internal/runner/producer.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"go-msg-queue-mini/client"
+	"go-msg-queue-mini/internal"
 	"go-msg-queue-mini/util"
 	"log/slog"
 	"time"
@@ -19,20 +20,23 @@ func (p *Producer) Produce(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		default:
-			item := util.GenerateItem() // Generate a new item
-			p.produce(item)
+			enqueueMsg := internal.EnqueueMessage{ // Generate a new item
+				Item:  util.GenerateItem(),
+				Delay: "0s", // Default delay
+			}
+			p.produce(enqueueMsg)
 			second := util.GenerateNumber(1, 5)             // Generate a random number between 1 and 5
 			time.Sleep(time.Duration(second) * time.Second) // Simulate processing time
 		}
 	}
 }
 
-func (p *Producer) produce(item interface{}) {
+func (p *Producer) produce(enqueueMsg internal.EnqueueMessage) {
 	logger := p.Client.Logger
-	err := p.Client.Produce(item, "3s")
+	err := p.Client.Produce(enqueueMsg)
 	if err != nil {
 		logger.Error("Error producing item", slog.String("producer", p.Name), slog.String("error", err.Error()))
 		return
 	}
-	logger.Info("Produced item", slog.String("producer", p.Name), slog.String("item", item.(string)))
+	logger.Info("Produced item", slog.String("producer", p.Name), slog.Any("item", enqueueMsg.Item))
 }

--- a/proto/queue.proto
+++ b/proto/queue.proto
@@ -83,9 +83,13 @@ message DeleteQueueResponse {
 // HTTP: EnqueueRequest{ message json.RawMessage }
 message EnqueueRequest {
   string queue_name = 1;
-  string message = 2;
-  string delay = 3; // optional, e.g., "5s","10m"
-  string deduplication_id = 4; // optional
+  EnqueueMessage message = 2;
+}
+
+message EnqueueMessage {
+  string message = 1;
+  string delay = 2; // optional, e.g., "5s","10m"
+  string deduplication_id = 3; // optional
 }
 
 // HTTP: EnqueueResponse{ status, message }
@@ -99,9 +103,7 @@ message EnqueueResponse {
 message EnqueueBatchRequest {
   string queue_name = 1;
   string mode = 2;
-  repeated string messages = 3;
-  string delay = 4; // optional, e.g., "10s", "5m"
-  string deduplication_id = 5; // optional
+  repeated EnqueueMessage messages = 3;
 }
 
 // EnqueueBatch response

--- a/proto/queue.proto
+++ b/proto/queue.proto
@@ -84,14 +84,15 @@ message DeleteQueueResponse {
 message EnqueueRequest {
   string queue_name = 1;
   string message = 2;
-  string delay = 3;
+  string delay = 3; // optional, e.g., "5s","10m"
+  string deduplication_id = 4; // optional
 }
 
 // HTTP: EnqueueResponse{ status, message }
 message EnqueueResponse {
   string status = 1;           // e.g., "enqueued"
   string queue_name = 2;
-  string  message = 3;          // 원본 페이로드 에코백
+  string message = 3;          // 원본 페이로드 에코백
 }
 
 // EnqueueBatch request
@@ -99,7 +100,8 @@ message EnqueueBatchRequest {
   string queue_name = 1;
   string mode = 2;
   repeated string messages = 3;
-  string delay = 4; // e.g., "10s", "5m"
+  string delay = 4; // optional, e.g., "10s", "5m"
+  string deduplication_id = 5; // optional
 }
 
 // EnqueueBatch response

--- a/util/partition.go
+++ b/util/partition.go
@@ -1,10 +1,10 @@
 package util
 
-func ChunkSlice(list []any, chunkSize int) [][]any {
+func ChunkSlice[T any](list []T, chunkSize int) [][]T {
 	if chunkSize <= 0 {
-		return [][]any{list}
+		return [][]T{list}
 	}
-	var chunks [][]any
+	var chunks [][]T
 	total := len(list)
 	for i := 0; i < total; i += chunkSize {
 		end := i + chunkSize

--- a/util/timeUtil.go
+++ b/util/timeUtil.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"fmt"
+	"time"
+)
+
+// delay 문자열을 seconds 단위로 변환
+// 빈 문자열인 경우 즉시 처리 (0초 지연)
+
+func DelayToSeconds(delay string) (string, error) {
+	mod := fmt.Sprintf("+%d seconds", 0)
+	if delay == "" {
+		return mod, nil
+	}
+	dur, err := time.ParseDuration(delay)
+	if err != nil {
+		return "", err
+	}
+	sec := int(dur.Round(time.Second).Seconds())
+	if sec < 0 {
+		sec = 0
+	}
+	return fmt.Sprintf("+%d seconds", sec), nil
+}


### PR DESCRIPTION
이 풀 리퀘스트는 메시지 큐 시스템에 메시지 중복 제거 기능을 도입하여 HTTP 및 gRPC 큐 작업 모두의 멱등성을 향상시킵니다. 새로운 `deduplication_id` 기능을 반영하기 위해 영어 및 한국어 API와 문서를 업데이트하고, 이 기능 및 향후 확장성을 지원하기 위해 gRPC protobuf 정의를 리팩토링합니다.

**주요 기능: 메시지 중복 제거**

- 큐에 추가(단일 및 일괄 모두) 시 선택적 `deduplication_id` 지원을 추가하여 1시간 내에 큐당 동일한 메시지가 두 번 이상 추가되는 것을 방지합니다. 중복 시도는 오류를 반환하거나 일괄 모드에서는 실패로 보고됩니다.  [[1]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213R17) [[2]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213L149-R158) [[3]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213L189-R191) [[4]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213R219) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L149-R158) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L189-R191) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R216)

**API 및 protobuf 변경**

- gRPC `EnqueueRequest` 및 `EnqueueBatchRequest`를 리팩터링하여 `message`, `delay` 및 `deduplication_id` 필드를 포함하는 새로운 `EnqueueMessage` 메시지 유형을 사용합니다. 이를 통해 API의 유연성과 확장성이 향상됩니다.  [[1]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL288-R288) [[2]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL331-R396) [[3]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL357-R409) [[4]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL369-R421) [[5]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL382-R434) [[6]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL411-R470) [[7]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL431-R482) [[8]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL444-R495) [[9]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL461-L474) [[10]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL489-R533) [[11]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL501-R545) [[12]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL514-R558) [[13]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL564-R608) [[14]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL576-R620) [[15]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL589-R633) [[16]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL625-R669) [[17]](diffhunk://#diff-ab7ec240023c1dcd12c5affa8a814029b53b24c80d14efc645736bded372af2bL637-R681)

- 클라이언트 인터페이스가 업데이트되었습니다. `Produce` 메서드는 이제 새로운 API에 맞춰 별도의 매개변수 대신 `EnqueueMessage` 구조체를 사용합니다.

**문서 업데이트**

- 새로운 중복 제거 기능을 설명하기 위해 영어(`README.en.md`) 및 한국어(`README.md`) 문서를 업데이트했습니다. 여기에는 API 요청/응답 예시와 단일 및 일괄 큐에 대한 동작 관련 참고 사항이 포함됩니다.  [[1]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213R17) [[2]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213L149-R158) [[3]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213L189-R191) [[4]](diffhunk://#diff-b4f47ddd2e9baf4f63a8b1c7adb79cc6caabfe2958e82d73d7b80d1468075213R219) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L149-R158) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L189-R191) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R216)