### PR TITLE
hot-fix: Update payload handling in peekHandler to use formatted payload

### DIFF
--- a/internal/api/http/handler.go
+++ b/internal/api/http/handler.go
@@ -320,13 +320,9 @@ func (h *httpServerInstance) peekHandler(c *gin.Context) {
 				payloadStr = string(payloadBytes)
 			}
 			// cut preview length with rune safety
-			if len(payloadStr) > peekMsgPreviewLength {
-				runes := []rune(payloadStr)
-				if len(runes) > peekMsgPreviewLength {
-					payloadStr = string(runes[:peekMsgPreviewLength]) + "..."
-				} else {
-					payloadStr = string(runes) + "..."
-				}
+			runes := []rune(payloadStr)
+			if len(runes) > peekMsgPreviewLength {
+				payloadStr = string(runes[:peekMsgPreviewLength]) + "..."
 			}
 			payload = payloadStr
 		}


### PR DESCRIPTION
This pull request makes a minor change to the `peekHandler` function in `internal/api/http/handler.go`. The update changes the assignment of the `Payload` field in the `DequeueMessage` struct to use `payloadStr` instead of `msg.Payload`. This likely ensures the payload is represented as a string, possibly for consistency or compatibility.

([internal/api/http/handler.goL328-R328](diffhunk://#diff-7014df613327be0898840e3856363c9051d0804b923dd8751d24de5952e50535L328-R328))